### PR TITLE
Enable resteasy async job support

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -24,22 +24,23 @@ dependencies {
     compile project('api')
     compile project('insights-inventory-client')
     compile 'org.jboss.spec.javax.ws.rs:jboss-jaxrs-api_2.1_spec:1.0.2.Final'
-    compile 'org.springframework:spring-beans:5.0.8.RELEASE'
-    compile 'org.springframework.boot:spring-boot:2.0.4.RELEASE'
-    compile 'org.springframework.boot:spring-boot-autoconfigure:2.0.4.RELEASE'
-    compile 'org.springframework:spring-context:5.0.8.RELEASE'
+    compile 'org.springframework.boot:spring-boot-autoconfigure:2.1.2.RELEASE'
+    compile 'org.springframework.boot:spring-boot:2.1.2.RELEASE'
+    compile 'org.springframework:spring-beans:5.1.4.RELEASE'
+    compile 'org.springframework:spring-context:5.1.4.RELEASE'
     compile 'org.slf4j:slf4j-api:1.7.25'
 
     // Runtime deps that will be included in the result package but not on the compile classpath.  I.e.
     // implementations of APIs we are using.
     runtime 'ch.qos.logback:logback-classic:1.2.3'
-    runtime 'org.jboss.resteasy:resteasy-spring-boot-starter:2.0.1.Final'
+    runtime 'org.jboss.resteasy:resteasy-spring-boot-starter:3.0.0.Final'
     runtime 'org.jboss.resteasy:resteasy-jaxrs:3.6.2.Final'
     runtime 'org.jboss.resteasy:resteasy-validator-provider-11:3.6.2.Final'
     runtime 'org.hibernate.validator:hibernate-validator:6.0.14.Final'
 
     testCompile 'org.junit.jupiter:junit-jupiter-api:5.3.2'
     testRuntime 'org.junit.jupiter:junit-jupiter-engine:5.3.2'
+
 
 //    testCompile 'org.mockito:mockito-core:2.23.4'
 //    testCompile 'org.mockito:mockito-junit-jupiter:2.23.4'

--- a/build.gradle
+++ b/build.gradle
@@ -23,6 +23,7 @@ bootJar {
 dependencies {
     compile project('api')
     compile project('insights-inventory-client')
+    compile 'javax.servlet:javax.servlet-api:3.1.0'
     compile 'org.jboss.spec.javax.ws.rs:jboss-jaxrs-api_2.1_spec:1.0.2.Final'
     compile 'org.springframework.boot:spring-boot-autoconfigure:2.1.2.RELEASE'
     compile 'org.springframework.boot:spring-boot:2.1.2.RELEASE'

--- a/src/main/java/org/candlepin/insights/ApplicationConfiguration.java
+++ b/src/main/java/org/candlepin/insights/ApplicationConfiguration.java
@@ -1,0 +1,45 @@
+/**
+ * Copyright (c) 2009 - 2019 Red Hat, Inc.
+ *
+ * This software is licensed to you under the GNU General Public License,
+ * version 2 (GPLv2). There is NO WARRANTY for this software, express or
+ * implied, including the implied warranties of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. You should have received a copy of GPLv2
+ * along with this software; if not, see
+ * http://www.gnu.org/licenses/old-licenses/gpl-2.0.txt.
+ *
+ * Red Hat trademarks are not licensed under GPLv2. No permission is
+ * granted to use or replicate Red Hat trademarks that are incorporated
+ * in this software or its documentation.
+ */
+package org.candlepin.insights;
+
+import org.springframework.boot.web.servlet.ServletContextInitializer;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+import javax.servlet.ServletContext;
+import javax.servlet.ServletException;
+
+/** Class to hold configuration beans */
+@Configuration
+public class ApplicationConfiguration {
+    /**
+     * Used to set context-param values since Spring Boot does not have a web.xml.  Technically
+     * context-params can be set in application.properties (or application.yaml) with the prefix
+     * "server.servlet.context-parameters" but the Spring Boot documentation kind of hides that
+     * information and the Bean approach seems to be considered the best practice.
+     * @return a configured ServletContextInitializer
+     */
+    @Bean
+    public ServletContextInitializer initializer() {
+        return new ServletContextInitializer() {
+
+            @Override
+            public void onStartup(ServletContext servletContext) throws ServletException {
+                servletContext.setInitParameter("resteasy.async.job.service.enabled", "true");
+                servletContext.setInitParameter("resteasy.async.job.service.base.path", "/jobs");
+            }
+        };
+    }
+}

--- a/src/main/resources/application.yaml
+++ b/src/main/resources/application.yaml
@@ -13,17 +13,3 @@ management:
   endpoint:
     shutdown:
       enabled: true
-
-# Used to set context-param values since Spring Boot does not have a web.xml.
-# The Spring Boot documentation does not really explicitly show that this style
-# of setting context-params is an option.  The more common method seems to be
-# the creation of a @Configuration class with a ServletContextInitializer @Bean
-# (See https://stackoverflow.com/a/26648258/6124862).  However, using this approach
-# requires adding the javax.servlet-api jar to our class path since the Bean receives
-# a ServletContext object.  Nebula Lint does not like that since the javax.servlet-api
-# jar contains classes duplicated in tomcat-embedded-core.  And no matter how you
-# slice it (add one, add the other, add both), the linter complains.  So we will use
-# this simple approach for now and move to the @Bean approach if necessary.
-server.servlet.context-parameters:
-  resteasy.async.job.service:
-    enabled: true

--- a/src/main/resources/application.yaml
+++ b/src/main/resources/application.yaml
@@ -13,3 +13,17 @@ management:
   endpoint:
     shutdown:
       enabled: true
+
+# Used to set context-param values since Spring Boot does not have a web.xml.
+# The Spring Boot documentation does not really explicitly show that this style
+# of setting context-params is an option.  The more common method seems to be
+# the creation of a @Configuration class with a ServletContextInitializer @Bean
+# (See https://stackoverflow.com/a/26648258/6124862).  However, using this approach
+# requires adding the javax.servlet-api jar to our class path since the Bean receives
+# a ServletContext object.  Nebula Lint does not like that since the javax.servlet-api
+# jar contains classes duplicated in tomcat-embedded-core.  And no matter how you
+# slice it (add one, add the other, add both), the linter complains.  So we will use
+# this simple approach for now and move to the @Bean approach if necessary.
+server.servlet.context-parameters:
+  resteasy.async.job.service:
+    enabled: true


### PR DESCRIPTION
Enables [Resteasy async job support](https://docs.jboss.org/resteasy/docs/3.6.2.Final/userguide/html_single/index.html#async_job)

Test as follows:
* Implement a basic version of Inventory API and have `updateInventoryForOrg` just sleep for 30 seconds.
* Deploy
* `curl -v -X POST 'http://localhost:8080/rhsm-conduit/inventory/1235?asynch=true'`  Adjust the port as you need to
* Look at the location header and fetch that URL with curl.  E.g.
  ```
  $ curl -v http://localhost:9166/rhsm-conduit/asynch/jobs/1548792335258-887705619
  [...]
  HTTP/1.1 202
  $ !! # after waiting 30 seconds
  [...]
  HTTP/1.1 204
  ```

  The job completes and we get back a 204 since this particular endpoint doesn't return anything