### PR TITLE
Set build to 1GB, remove route from template

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,3 +12,16 @@ First, log in to an openshift instance.
 oc create -f openshift/template_rhsm-conduit.yaml  # add a template for deploying rhsm-conduit
 oc new-app --template=rhsm-conduit  # deploy an instance of rhsm-conduit using the template
 ```
+
+By default, the template deploys the master branch of rhsm-conduit. If it's more appropriate to deploy a different branch (e.g. production), then use:
+
+```
+oc new-app --template=rhsm-conduit -p SOURCE_REPOSITORY_REF=production
+```
+
+If, for debugging on a local machine, for convenience, you need a route to test rhsm-conduit,
+
+```
+oc create -f openshift/template_rhsm-conduit-route.yaml
+oc new-app --template=rhsm-conduit-route
+```

--- a/openshift/template_rhsm-conduit-route.yaml
+++ b/openshift/template_rhsm-conduit-route.yaml
@@ -1,0 +1,26 @@
+apiVersion: v1
+kind: Template
+metadata:
+  name: rhsm-conduit-route
+objects:
+- apiVersion: v1
+  kind: Route
+  metadata:
+    labels:
+      app: ${APPLICATION_NAME}
+    name: ${APPLICATION_NAME}
+  spec:
+    host: ${HOSTNAME_HTTP}
+    to:
+      name: ${APPLICATION_NAME}
+parameters:
+- description: The name for the application.
+  displayName: Application Name
+  name: APPLICATION_NAME
+  value: rhsm-conduit
+  required: false
+- description: 'Custom hostname for http service route.  Leave blank for default hostname, e.g.: <application-name>-<project>.<default-domain-suffix>'
+  displayName: Custom http Route Hostname
+  name: HOSTNAME_HTTP
+  value: ''
+  required: false

--- a/openshift/template_rhsm-conduit.yaml
+++ b/openshift/template_rhsm-conduit.yaml
@@ -72,22 +72,15 @@ objects:
     - github:
         secret: ${GITHUB_WEBHOOK_SECRET}
       type: GitHub
+    resources:
+      limits:
+        memory: "1Gi"
 - apiVersion: v1
   kind: ImageStream
   metadata:
     labels:
       app: ${APPLICATION_NAME}
     name: ${APPLICATION_NAME}
-- apiVersion: v1
-  kind: Route
-  metadata:
-    labels:
-      app: ${APPLICATION_NAME}
-    name: ${APPLICATION_NAME}
-  spec:
-    host: ${HOSTNAME_HTTP}
-    to:
-      name: ${APPLICATION_NAME}
 - apiVersion: v1
   kind: Service
   metadata:
@@ -115,11 +108,6 @@ parameters:
   displayName: Application Name
   name: APPLICATION_NAME
   value: rhsm-conduit
-  required: false
-- description: 'Custom hostname for http service route.  Leave blank for default hostname, e.g.: <application-name>-<project>.<default-domain-suffix>'
-  displayName: Custom http Route Hostname
-  name: HOSTNAME_HTTP
-  value: ''
   required: false
 - description: GitHub trigger secret
   displayName: Github Webhook Secret


### PR DESCRIPTION
Build needed to be 1GB to avoid OOM-kill on the default.

The route should not be deployed by default, as this service only needs
to be internally callable.