### PR TITLE
Enable reading /etc/rhsm-conduit.conf

### DIFF
--- a/src/main/java/org/candlepin/insights/ApplicationConfiguration.java
+++ b/src/main/java/org/candlepin/insights/ApplicationConfiguration.java
@@ -14,16 +14,28 @@
  */
 package org.candlepin.insights;
 
+import org.candlepin.insights.inventory.client.ApiClientFactory;
+
+import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.web.servlet.ServletContextInitializer;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.context.annotation.PropertySource;
+import org.springframework.core.env.Environment;
 
 import javax.servlet.ServletContext;
 import javax.servlet.ServletException;
 
 /** Class to hold configuration beans */
 @Configuration
+@PropertySource(
+    value = {"classpath:/project.properties", "file:/etc/rhsm-conduit.conf"},
+    ignoreResourceNotFound = true
+)
 public class ApplicationConfiguration {
+    @Autowired
+    Environment env;
+
     /**
      * Used to set context-param values since Spring Boot does not have a web.xml.  Technically
      * context-params can be set in application.properties (or application.yaml) with the prefix
@@ -41,5 +53,10 @@ public class ApplicationConfiguration {
                 servletContext.setInitParameter("resteasy.async.job.service.base.path", "/jobs");
             }
         };
+    }
+
+    @Bean
+    public ApiClientFactory hostInventoryClientFactory() {
+        return new ApiClientFactory(env.getProperty("hostInventoryServiceUrl"));
     }
 }

--- a/src/main/java/org/candlepin/insights/inventory/client/ApiClientFactory.java
+++ b/src/main/java/org/candlepin/insights/inventory/client/ApiClientFactory.java
@@ -1,0 +1,49 @@
+/**
+ * Copyright (c) 2009 - 2019 Red Hat, Inc.
+ *
+ * This software is licensed to you under the GNU General Public License,
+ * version 2 (GPLv2). There is NO WARRANTY for this software, express or
+ * implied, including the implied warranties of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. You should have received a copy of GPLv2
+ * along with this software; if not, see
+ * http://www.gnu.org/licenses/old-licenses/gpl-2.0.txt.
+ *
+ * Red Hat trademarks are not licensed under GPLv2. No permission is
+ * granted to use or replicate Red Hat trademarks that are incorporated
+ * in this software or its documentation.
+ */
+package org.candlepin.insights.inventory.client;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.beans.factory.FactoryBean;
+
+public class ApiClientFactory implements FactoryBean<ApiClient> {
+    private static Logger log = LoggerFactory.getLogger(ApiClientFactory.class);
+
+    private String hostInventoryServiceUrl;
+
+    public ApiClientFactory(String hostInventoryServiceUrl) {
+        if (hostInventoryServiceUrl != null) {
+            log.info("host inventory service URL: {}", hostInventoryServiceUrl);
+        }
+        else {
+            log.info("host inventory service URL not set...");
+        }
+        this.hostInventoryServiceUrl = hostInventoryServiceUrl;
+    }
+
+    @Override
+    public ApiClient getObject() throws Exception {
+        ApiClient client = new ApiClient();
+        if (hostInventoryServiceUrl != null) {
+            client.setBasePath(hostInventoryServiceUrl);
+        }
+        return client;
+    }
+
+    @Override
+    public Class<?> getObjectType() {
+        return ApiClient.class;
+    }
+}

--- a/src/test/java/org/candlepin/insights/inventory/client/ApiClientTest.java
+++ b/src/test/java/org/candlepin/insights/inventory/client/ApiClientTest.java
@@ -1,0 +1,20 @@
+package org.candlepin.insights.inventory.client;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.context.TestPropertySource;
+
+@SpringBootTest
+@TestPropertySource("classpath:/test.properties")
+public class ApiClientTest {
+    @Autowired
+    private ApiClient client;
+
+    @Test
+    public void testServiceUrlConfigurableViaProperties() {
+        assertEquals("https://localhost/api/hostinventory", client.getBasePath());
+    }
+}

--- a/src/test/resources/test.properties
+++ b/src/test/resources/test.properties
@@ -1,0 +1,2 @@
+application.version=TEST
+hostInventoryServiceUrl=https://localhost/api/hostinventory


### PR DESCRIPTION
To test, create a file: /etc/rhsm-conduit.conf with
hostInventoryServiceUrl set to foobar and then launch the jar;
observe the message:

```
host inventory service URL: foobar
```

Also, this adds a factory for the host inventory client that is
constructed using this config key. This pattern can be used in other
other swagger clients.

With the factory in place, it is sufficient to `@Autowire` in a ApiClient,
as seen in ApiClientTest.