### PR TITLE
Create templated cronjob to hit inventory org sync

### DIFF
--- a/openshift/template_rhsm-conduit-syncjob.yaml
+++ b/openshift/template_rhsm-conduit-syncjob.yaml
@@ -1,0 +1,44 @@
+apiVersion: v1
+kind: Template
+metadata:
+  name: rhsm-conduit-syncjob
+objects:
+- apiVersion: batch/v1beta1
+  kind: CronJob
+  metadata:
+    name: ${APPLICATION_NAME}-syncjob
+    labels:
+      app: ${APPLICATION_NAME}
+  spec:
+    schedule: ${SYNC_SCHEDULE}
+    jobTemplate:
+      spec:
+        template:
+          metadata:
+            labels:
+              parent: ${APPLICATION_NAME}-syncjob
+          spec:
+            containers:
+            - name: ${APPLICATION_NAME}-syncjob
+              image: registry.access.redhat.com/rhel7
+              args: ['/bin/bash', '-c', 'echo ${SYNC_ORGS} | tr " " "\n" | xargs -l -I{} curl -v -X POST ${SYNC_ENDPOINT}/{}']
+            restartPolicy: OnFailure
+parameters:
+- description: The name for the application.
+  displayName: Application Name
+  name: APPLICATION_NAME
+  value: rhsm-conduit
+  required: false
+- description: Sync schedule
+  displayName: Sync schedule
+  name: SYNC_SCHEDULE
+  value: '0 3 * * *'
+  required: false
+- description: List of orgs to sync on a regular basis, separated by a space or newline
+  displayName: Sync orgs
+  name: SYNC_ORGS
+  required: true
+- description: Sync endpoint (ex. http://rhsm-conduit.example.com:8080/rhsm-conduit/inventory)
+  displayName: Sync endpoint
+  name: SYNC_ENDPOINT
+  required: true


### PR DESCRIPTION
To test, can use:

```
oc apply -f openshift/template_rhsm-conduit-syncjob.yaml
export SYNC_HOSTNAME=rhsm-conduit.myproject.svc  # modify this if necessary
oc new-app --template=rhsm-conduit-syncjob -p SYNC_ORGS="org1 org2" -p SYNC_ENDPOINT=http://$SYNC_HOSTNAME:8080/rhsm-conduit/inventory -p SYNC_SCHEDULE='* * * * *'
```

Once deployed this way, once per minute (roughly), the cronjob will curl
the endpoint for each configured org.

To undeploy and redeploy with a different config:

```
oc delete cronjob rhsm-conduit-syncjob
oc new-app --template=rhsm-conduit-syncjob -p SYNC_ORGS="org1 org2" -p SYNC_ENDPOINT=http://$SYNC_HOSTNAME:8080/rhsm-conduit/inventory -p SYNC_SCHEDULE='* * * * *'  # modify as necessary
```