### PR TITLE
Update the host inventory via the generated client

### DIFF
--- a/insights-inventory-client/build.gradle
+++ b/insights-inventory-client/build.gradle
@@ -6,7 +6,7 @@ ext {
     swagger_annotations_version = "1.5.21"
     jackson_version = "2.8.11"
     jackson_databind_version = "2.8.11.2"
-    resteasy_version = "3.1.3.Final"
+    resteasy_version = "3.6.2.Final"
 
     api_spec_path = "https://raw.githubusercontent.com/RedHatInsights/insights-host-inventory/master/swagger/api.spec.yaml"
 }

--- a/src/main/java/org/candlepin/insights/controller/InventoryController.java
+++ b/src/main/java/org/candlepin/insights/controller/InventoryController.java
@@ -1,0 +1,41 @@
+/**
+ * Copyright (c) 2009 - 2019 Red Hat, Inc.
+ *
+ * This software is licensed to you under the GNU General Public License,
+ * version 2 (GPLv2). There is NO WARRANTY for this software, express or
+ * implied, including the implied warranties of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. You should have received a copy of GPLv2
+ * along with this software; if not, see
+ * http://www.gnu.org/licenses/old-licenses/gpl-2.0.txt.
+ *
+ * Red Hat trademarks are not licensed under GPLv2. No permission is
+ * granted to use or replicate Red Hat trademarks that are incorporated
+ * in this software or its documentation.
+ */
+package org.candlepin.insights.controller;
+
+import org.candlepin.insights.inventory.client.InventoryService;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Component;
+
+import java.util.UUID;
+
+/**
+ * Controller used to interact with the Inventory service.
+ */
+@Component
+public class InventoryController {
+
+    private static Logger log = LoggerFactory.getLogger(InventoryController.class);
+
+    @Autowired
+    private InventoryService inventoryService;
+
+    public void updateInventoryForOrg(String orgId) {
+        inventoryService.sendHostUpdate(orgId, "Host 1", "host1.test.com", UUID.randomUUID());
+        inventoryService.sendHostUpdate(orgId, "Host 2", "host2.test.com", UUID.randomUUID());
+    }
+}

--- a/src/main/java/org/candlepin/insights/exceptions/RhsmConduitException.java
+++ b/src/main/java/org/candlepin/insights/exceptions/RhsmConduitException.java
@@ -1,0 +1,40 @@
+/**
+ * Copyright (c) 2009 - 2019 Red Hat, Inc.
+ *
+ * This software is licensed to you under the GNU General Public License,
+ * version 2 (GPLv2). There is NO WARRANTY for this software, express or
+ * implied, including the implied warranties of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. You should have received a copy of GPLv2
+ * along with this software; if not, see
+ * http://www.gnu.org/licenses/old-licenses/gpl-2.0.txt.
+ *
+ * Red Hat trademarks are not licensed under GPLv2. No permission is
+ * granted to use or replicate Red Hat trademarks that are incorporated
+ * in this software or its documentation.
+ */
+package org.candlepin.insights.exceptions;
+
+import org.candlepin.insights.api.model.Error;
+
+/**
+ * Application's base exception class. Provides a means to create an
+ * Error object that should be typically return as part of an error
+ * response.
+ */
+public class RhsmConduitException extends RuntimeException {
+
+    private int code;
+
+    public RhsmConduitException(int code, String message) {
+        super(message);
+        this.code = code;
+    }
+
+    public int code() {
+        return this.code;
+    }
+
+    public Error error() {
+        return new Error().code(this.code).message(this.getMessage());
+    }
+}

--- a/src/main/java/org/candlepin/insights/inventory/InventoryService.java
+++ b/src/main/java/org/candlepin/insights/inventory/InventoryService.java
@@ -1,0 +1,108 @@
+/**
+ * Copyright (c) 2009 - 2019 Red Hat, Inc.
+ *
+ * This software is licensed to you under the GNU General Public License,
+ * version 2 (GPLv2). There is NO WARRANTY for this software, express or
+ * implied, including the implied warranties of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. You should have received a copy of GPLv2
+ * along with this software; if not, see
+ * http://www.gnu.org/licenses/old-licenses/gpl-2.0.txt.
+ *
+ * Red Hat trademarks are not licensed under GPLv2. No permission is
+ * granted to use or replicate Red Hat trademarks that are incorporated
+ * in this software or its documentation.
+ */
+package org.candlepin.insights.inventory.client;
+
+import org.candlepin.insights.exceptions.RhsmConduitException;
+import org.candlepin.insights.inventory.client.model.FactSet;
+import org.candlepin.insights.inventory.client.model.Host;
+import org.candlepin.insights.inventory.client.model.HostOut;
+import org.candlepin.insights.inventory.client.resources.HostsApi;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Component;
+
+import java.util.HashMap;
+import java.util.LinkedList;
+import java.util.List;
+import java.util.Map;
+import java.util.UUID;
+
+/**
+ * A wrapper for the insights inventory client.
+ */
+@Component
+public class InventoryService {
+
+    private static Logger log = LoggerFactory.getLogger(InventoryService.class);
+
+    private HostsApi hostsInventoryApi;
+
+    @Autowired
+    public InventoryService(ApiClient inventoryApiClient) throws Exception {
+        hostsInventoryApi = new HostsApi(inventoryApiClient);
+    }
+
+    // TODO Update the parameters once we know what will be coming from the RHSM service.
+    public HostOut sendHostUpdate(String orgId, String displayName, String hostName, UUID rhsmUuid)
+        throws RhsmConduitException {
+        try {
+            return hostsInventoryApi.apiHostAddHost(forgeAuthHeader(orgId),
+                createHost(orgId, displayName, hostName, rhsmUuid));
+        }
+        catch (Exception e) {
+            // FIXME This should all get removed once the exception mappers are in place.
+            log.error("An exception occurred during request.", e);
+            int code = 500;
+            String message = e.getMessage();
+            if (e instanceof ApiException) {
+                ApiException apie = (ApiException) e;
+                code = apie.getCode();
+                message = apie.getResponseBody();
+            }
+            log.error("Could not update host. Reason: {}", message);
+            throw new RhsmConduitException(code, message);
+        }
+    }
+
+    private byte[] forgeAuthHeader(String accountNumber) {
+        return "b".getBytes();
+    }
+
+    /**
+     * TODO Remove once we are pulling data from the pinhead API.
+     *
+     * @return the new host.
+     */
+    private Host createHost(String orgId, String displayName, String fqdn, UUID submanUUID) {
+        Map<String, String> rhsmFactMap = new HashMap<>();
+        rhsmFactMap.put("orgId", orgId);
+        rhsmFactMap.put("is_virt", Boolean.FALSE.toString());
+
+        FactSet rhsmFacts = new FactSet()
+            .namespace("rhsm")
+            .facts(rhsmFactMap);
+        List<FactSet> facts = new LinkedList<>();
+        facts.add(rhsmFacts);
+
+        Host host = new Host();
+        // Magic account number that tells the inventory app to
+        // ignore the auth header account check. When running
+        // against production insights-inventory, the account in
+        // the header must match what is set on the Host.
+        //
+        // In hosted the account will be the orgId.
+        // TODO Properly set the account when we determine how
+        //      auth will work going forward.
+        host.setAccount("0000001");
+        host.setFqdn(fqdn);
+        host.setDisplayName(displayName);
+        host.setSubscriptionManagerId(submanUUID);
+        host.facts(facts);
+        return host;
+    }
+
+}

--- a/src/main/java/org/candlepin/insights/resource/InventoryResource.java
+++ b/src/main/java/org/candlepin/insights/resource/InventoryResource.java
@@ -1,0 +1,48 @@
+/**
+ * Copyright (c) 2009 - 2019 Red Hat, Inc.
+ *
+ * This software is licensed to you under the GNU General Public License,
+ * version 2 (GPLv2). There is NO WARRANTY for this software, express or
+ * implied, including the implied warranties of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. You should have received a copy of GPLv2
+ * along with this software; if not, see
+ * http://www.gnu.org/licenses/old-licenses/gpl-2.0.txt.
+ *
+ * Red Hat trademarks are not licensed under GPLv2. No permission is
+ * granted to use or replicate Red Hat trademarks that are incorporated
+ * in this software or its documentation.
+ */
+package org.candlepin.insights.resource;
+
+import org.candlepin.insights.api.model.OrgInventory;
+import org.candlepin.insights.api.resources.InventoryApi;
+import org.candlepin.insights.controller.InventoryController;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Component;
+
+import javax.validation.constraints.NotNull;
+
+/**
+ * The inventory API implementation.
+ */
+@Component
+public class InventoryResource implements InventoryApi {
+
+    private static Logger log = LoggerFactory.getLogger(InventoryResource.class);
+
+    @Autowired
+    private InventoryController inventoryController;
+
+    @Override
+    public OrgInventory getInventoryForOrg(@NotNull byte[] xRhIdentity, String orgId) {
+        return new OrgInventory();
+    }
+
+    @Override
+    public void updateInventoryForOrg(@NotNull byte[] xRhIdentity, String orgId) {
+        inventoryController.updateInventoryForOrg(orgId);
+    }
+}


### PR DESCRIPTION
This PR allows us to send bogus host information to the insights-inventory service via the rhsm-conduit POST /inventory/:org_id API.

## To Test
This PR depends on the template from #4. See the README.md in that PR to get insights-inventory deployed.

Once inventory is deployed:
1. Edit the rhsm-conduit config example to update the URL of the inventory service created above.
```
hostInventoryServiceUrl=http://insights-inventory.myproject.svc:8080/r/insights/platform/inventory/api/v1
```

2. Create the ConfigMap:
```
$ oc create configmap rhsm-conduit-config --from-file openshift/example_config
```

3. Ensure that you are using the latest template for rhsm-conduit. I'd remove the old one and recreate it.
```
$ oc create -f openshift/template_rhsm-conduit.yaml  # add a template for deploying rhsm-conduit
$ oc new-app --template=rhsm-conduit -p SOURCE_REPOSITORY_REF=mstead/update_inventory_via_client
```
4. Once the application has been deployed, curl the endpoint with any random org. Two hosts will be added to the inventory each time it is invoked. I set up a route for rhsm-conduit to make the API public, but you can also curl from the app shell
```
$ curl -X POST http://YOUR_RHSM_CONDUIT_HOSTNAME/rhsm-conduit/inventory/1234
```

5. From the insights-inventory console, check to see that 2 hosts were added.
```
$ curl -X POST http://RHSM_INVENTORY_HOSTNAME:8080/r/insights/platform/inventory/api/v1/hosts
```