### PR TITLE
Configure logback for logstash via configmap

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -39,6 +39,7 @@ dependencies {
     compile "org.springframework:spring-beans:$spring_version"
     compile "org.springframework:spring-context:$spring_version"
     compile "org.slf4j:slf4j-api:1.7.25"
+    compile "net.logstash.logback:logstash-logback-encoder:5.3"
 
     // Runtime deps that will be included in the result package but not on the compile classpath.  I.e.
     // implementations of APIs we are using.

--- a/openshift/example_config/logback.xml
+++ b/openshift/example_config/logback.xml
@@ -1,0 +1,15 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<configuration scan="true" scanPeriod="60 seconds">
+    <contextName>rhsm-conduit</contextName>
+    <appender name="ConsoleAppender" class="ch.qos.logback.core.ConsoleAppender">
+        <encoder class="net.logstash.logback.encoder.LogstashEncoder" />
+    </appender>
+
+    <logger name="org.candlepin" level="INFO"/>
+
+    <root level="WARN">
+        <appender-ref ref="ConsoleAppender" />
+        <!--<appender-ref ref="RhsmConduitAppender" />-->
+        <!--<appender-ref ref="ErrorAppender" />-->
+    </root>
+</configuration>

--- a/openshift/template_rhsm-conduit.yaml
+++ b/openshift/template_rhsm-conduit.yaml
@@ -26,6 +26,9 @@ objects:
         - image: ${APPLICATION_NAME}
           imagePullPolicy: Always
           name: ${APPLICATION_NAME}
+          env:
+          - name: JAVA_OPTIONS
+            value: -Dlogging.config=/etc/logback.xml
           livenessProbe:
             failureThreshold: 3
             httpGet:
@@ -53,6 +56,9 @@ objects:
           - name: config
             mountPath: /etc/rhsm-conduit.conf
             subPath: rhsm-conduit.conf
+          - name: config
+            mountPath: /etc/logback.xml
+            subPath: logback.xml
         volumes:
         - name: config
           configMap:


### PR DESCRIPTION
I did not add any specific JSON fields, but I did test this without
committing.

You can add a line such as:

```java
log.info(net.logstash.logback.marker.Markers.append("foobar", "test"), "Someone made a request");
```

and see when run via:

```
java -Dlogging.config=openshift/example_config/logback.xml -jar build/libs/rhsm-conduit-1.0.0.jar
```

that the log is formatted as JSON and contains the foobar field.

A good candidate for the marker would be something like "org" to allow
us to see log events per org.

Also, as a bonus, having `logback.xml` in the configmap allows us to
modify it dynamically for debugging, etc., and using `scan` will make
the changes get picked up automatically without a re-deploy.