### PR TITLE
Added custom exception mappers so that we always return JSON Error

### DIFF
--- a/api/rhsm-conduit-api-spec.yaml
+++ b/api/rhsm-conduit-api-spec.yaml
@@ -193,13 +193,26 @@ components:
         availability:
           type: string
 
+    Errors:
+      required:
+        - errors
+      properties:
+        errors:
+          type: array
+          items:
+            $ref: "#/components/schemas/Error"
+
     Error:
       required:
+        - status
         - code
-        - message
+        - title
       properties:
+        status:
+          type: string
         code:
-          type: integer
-          format: int32
-        message:
+          type: string
+        title:
+          type: string
+        detail:
           type: string

--- a/src/main/java/org/candlepin/insights/exception/ErrorCode.java
+++ b/src/main/java/org/candlepin/insights/exception/ErrorCode.java
@@ -1,0 +1,103 @@
+/*
+ * Copyright (c) 2009 - 2019 Red Hat, Inc.
+ *
+ * This software is licensed to you under the GNU General Public License,
+ * version 2 (GPLv2). There is NO WARRANTY for this software, express or
+ * implied, including the implied warranties of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. You should have received a copy of GPLv2
+ * along with this software; if not, see
+ * http://www.gnu.org/licenses/old-licenses/gpl-2.0.txt.
+ *
+ * Red Hat trademarks are not licensed under GPLv2. No permission is
+ * granted to use or replicate Red Hat trademarks that are incorporated
+ * in this software or its documentation.
+ */
+package org.candlepin.insights.exception;
+
+/**
+ * Represents the various application codes.
+ *
+ * RHSMCONDUIT1XXX: General rhsm-conduit application error code space.
+ * RHSMCONDUIT2XXX: Insights Inventory API related application error code space.
+ * RHSMCONDUIT3XXX: Pinhead API related application error code space.
+ *
+ */
+public enum ErrorCode {
+
+    /**
+     * An unhandled exception has occurred. This typically implies that the
+     * exception was unexpected and likely due to a bug or coding error.
+     */
+    UNHANDLED_EXCEPTION_ERROR(1000, "An unhandled exception occurred"),
+
+    /**
+     * An exception was thrown by RestEasy while processing a request to the
+     * rhsm-conduit API. This typically means that an HTTP client error has
+     * occurred (HTTP 4XX).
+     */
+    REQUEST_PROCESSING_ERROR(1001, "An error occurred while processing a request."),
+
+    /**
+     * An unexpected exception was thrown by the inventory service client.
+     */
+    INVENTORY_SERVICE_ERROR(2000, "Inventory Service Error"),
+
+    /**
+     * The inventory service is unavailable. This typically means that the
+     * inventory service is either down, or the configured service URL is
+     * not correct, and a connection can not be made.
+     */
+    INVENTORY_SERVICE_UNAVAILABLE(2001, "The inventory service is unavailable"),
+
+    /**
+     * An exception was thrown by the inventory service when a request was made.
+     * This typically means that an HTTP client error has occurred (HTTP 4XX)
+     * when rhsm-conduit made the request.
+     */
+    INVENTORY_SERVICE_REQUEST_ERROR(2002, "Inventory API Error"),
+
+    /**
+     * An unexpected exception was thrown by the Pinhead service client.
+     */
+    PINHEAD_SERVICE_ERROR(3000, "Pinhead Service Error"),
+
+    /**
+     * The pinhead service is unavailable. This typically means that the
+     * pinhead service is either down, or the configured service URL is
+     * not correct, and a connection can not be made.
+     */
+    PINHEAD_SERVICE_UNAVAILABLE(3001, "The inventory service is unavailable"),
+
+    /**
+     * An exception was thrown by the pinhead service when a request was made.
+     * This typically means that an HTTP client error has occurred (HTTP 4XX)
+     * when rhsm-conduit made the request.
+     */
+    PINHEAD_SERVICE_REQUEST_ERROR(3002, "Inventory API Error");
+
+
+
+    private final String CODE_PREFIX = "RHSMCONDUIT";
+
+    private String code;
+    private String description;
+
+    ErrorCode(int intCode, String description) {
+        this.code = CODE_PREFIX + intCode;
+        this.description = description;
+    }
+
+    public String getCode() {
+        return this.code;
+    }
+
+    public String getDescription() {
+        return this.description;
+    }
+
+    @Override
+    public String toString() {
+        return String.format("%s: %s", code, description);
+    }
+
+}

--- a/src/main/java/org/candlepin/insights/exception/ExternalServiceException.java
+++ b/src/main/java/org/candlepin/insights/exception/ExternalServiceException.java
@@ -1,0 +1,29 @@
+/*
+ * Copyright (c) 2009 - 2019 Red Hat, Inc.
+ *
+ * This software is licensed to you under the GNU General Public License,
+ * version 2 (GPLv2). There is NO WARRANTY for this software, express or
+ * implied, including the implied warranties of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. You should have received a copy of GPLv2
+ * along with this software; if not, see
+ * http://www.gnu.org/licenses/old-licenses/gpl-2.0.txt.
+ *
+ * Red Hat trademarks are not licensed under GPLv2. No permission is
+ * granted to use or replicate Red Hat trademarks that are incorporated
+ * in this software or its documentation.
+ */
+package org.candlepin.insights.exception;
+
+import javax.ws.rs.core.Response.Status;
+
+/**
+ * An exception that is thrown when rhsm-conduit encounters an exception while
+ * communicating with an external service such as insights-inventory.
+ */
+public class ExternalServiceException extends RhsmConduitException {
+
+    public ExternalServiceException(ErrorCode code, String message, Throwable e) {
+        super(code, Status.INTERNAL_SERVER_ERROR, message, e);
+    }
+
+}

--- a/src/main/java/org/candlepin/insights/exception/NotReadyException.java
+++ b/src/main/java/org/candlepin/insights/exception/NotReadyException.java
@@ -1,0 +1,24 @@
+/*
+ * Copyright (c) 2009 - 2019 Red Hat, Inc.
+ *
+ * This software is licensed to you under the GNU General Public License,
+ * version 2 (GPLv2). There is NO WARRANTY for this software, express or
+ * implied, including the implied warranties of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. You should have received a copy of GPLv2
+ * along with this software; if not, see
+ * http://www.gnu.org/licenses/old-licenses/gpl-2.0.txt.
+ *
+ * Red Hat trademarks are not licensed under GPLv2. No permission is
+ * granted to use or replicate Red Hat trademarks that are incorporated
+ * in this software or its documentation.
+ */
+package org.candlepin.insights.exception;
+
+/**
+ * Exception thrown when the application is not ready (i.e. under heavy load).
+ */
+public class NotReadyException extends RuntimeException {
+    public NotReadyException(String s) {
+        super(s);
+    }
+}

--- a/src/main/java/org/candlepin/insights/exception/RhsmConduitException.java
+++ b/src/main/java/org/candlepin/insights/exception/RhsmConduitException.java
@@ -1,0 +1,63 @@
+/*
+ * Copyright (c) 2009 - 2019 Red Hat, Inc.
+ *
+ * This software is licensed to you under the GNU General Public License,
+ * version 2 (GPLv2). There is NO WARRANTY for this software, express or
+ * implied, including the implied warranties of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. You should have received a copy of GPLv2
+ * along with this software; if not, see
+ * http://www.gnu.org/licenses/old-licenses/gpl-2.0.txt.
+ *
+ * Red Hat trademarks are not licensed under GPLv2. No permission is
+ * granted to use or replicate Red Hat trademarks that are incorporated
+ * in this software or its documentation.
+ */
+package org.candlepin.insights.exception;
+
+import org.candlepin.insights.api.model.Error;
+
+import javax.ws.rs.core.Response.Status;
+
+/**
+ * Application's base exception class. Provides a means to create an
+ * Error object that should be typically return as part of an error
+ * response.
+ */
+public class RhsmConduitException extends RuntimeException {
+
+    private Status status;
+    private String detail;
+    private ErrorCode code;
+
+    public RhsmConduitException(ErrorCode code, Status status, String message, String detail) {
+        this(code, status, message, detail, null);
+    }
+
+    public RhsmConduitException(ErrorCode code, Status status, String message, Throwable e) {
+        this(code, status, message, e.getMessage(), e);
+    }
+
+    public RhsmConduitException(ErrorCode code, Status status, String message, String detail, Throwable e) {
+        super(message, e);
+        this.code = code;
+        this.status = status;
+        this.detail = detail;
+    }
+
+    public ErrorCode getCode() {
+        return this.code;
+    }
+
+    public Status getStatus() {
+        return this.status;
+    }
+
+    public Error error() {
+        return new Error()
+            .code(this.code.getCode())
+            .status(String.valueOf(status.getStatusCode()))
+            .title(this.getMessage())
+            .detail(this.detail);
+    }
+
+}

--- a/src/main/java/org/candlepin/insights/exception/inventory/InventoryServiceException.java
+++ b/src/main/java/org/candlepin/insights/exception/inventory/InventoryServiceException.java
@@ -12,29 +12,19 @@
  * granted to use or replicate Red Hat trademarks that are incorporated
  * in this software or its documentation.
  */
-package org.candlepin.insights.exceptions;
+package org.candlepin.insights.exception.inventory;
 
-import org.candlepin.insights.api.model.Error;
+import org.candlepin.insights.exception.ErrorCode;
+import org.candlepin.insights.exception.ExternalServiceException;
 
 /**
- * Application's base exception class. Provides a means to create an
- * Error object that should be typically return as part of an error
- * response.
+ * A general exception thrown when an uncaught error is encountered from the
+ * inventory service.
  */
-public class RhsmConduitException extends RuntimeException {
+public class InventoryServiceException extends ExternalServiceException {
 
-    private int code;
-
-    public RhsmConduitException(int code, String message) {
-        super(message);
-        this.code = code;
+    public InventoryServiceException(String message, Throwable e) {
+        super(ErrorCode.INVENTORY_SERVICE_ERROR, message, e);
     }
 
-    public int code() {
-        return this.code;
-    }
-
-    public Error error() {
-        return new Error().code(this.code).message(this.getMessage());
-    }
 }

--- a/src/main/java/org/candlepin/insights/exception/inventory/InventoryServiceRequestException.java
+++ b/src/main/java/org/candlepin/insights/exception/inventory/InventoryServiceRequestException.java
@@ -12,13 +12,18 @@
  * granted to use or replicate Red Hat trademarks that are incorporated
  * in this software or its documentation.
  */
-package org.candlepin.insights.jaxrs;
+package org.candlepin.insights.exception.inventory;
+
+import org.candlepin.insights.exception.ErrorCode;
+import org.candlepin.insights.exception.ExternalServiceException;
 
 /**
- * Exception thrown when the application is not ready (i.e. under heavy load).
+ * Thrown when there was an issue making a request to the inventory service.
  */
-public class NotReadyException extends RuntimeException {
-    public NotReadyException(String s) {
-        super(s);
+public class InventoryServiceRequestException extends ExternalServiceException {
+
+    public InventoryServiceRequestException(String message, Throwable e) {
+        super(ErrorCode.INVENTORY_SERVICE_REQUEST_ERROR, message, e);
     }
+
 }

--- a/src/main/java/org/candlepin/insights/exception/inventory/InventoryServiceUnavailableException.java
+++ b/src/main/java/org/candlepin/insights/exception/inventory/InventoryServiceUnavailableException.java
@@ -1,0 +1,29 @@
+/*
+ * Copyright (c) 2009 - 2019 Red Hat, Inc.
+ *
+ * This software is licensed to you under the GNU General Public License,
+ * version 2 (GPLv2). There is NO WARRANTY for this software, express or
+ * implied, including the implied warranties of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. You should have received a copy of GPLv2
+ * along with this software; if not, see
+ * http://www.gnu.org/licenses/old-licenses/gpl-2.0.txt.
+ *
+ * Red Hat trademarks are not licensed under GPLv2. No permission is
+ * granted to use or replicate Red Hat trademarks that are incorporated
+ * in this software or its documentation.
+ */
+package org.candlepin.insights.exception.inventory;
+
+import org.candlepin.insights.exception.ErrorCode;
+import org.candlepin.insights.exception.ExternalServiceException;
+
+/**
+ * Thrown when the inventory service is unavailable.
+ */
+public class InventoryServiceUnavailableException extends ExternalServiceException {
+
+    public InventoryServiceUnavailableException(String message, Throwable e) {
+        super(ErrorCode.INVENTORY_SERVICE_UNAVAILABLE, message, e);
+    }
+
+}

--- a/src/main/java/org/candlepin/insights/exception/mapper/BaseExceptionMapper.java
+++ b/src/main/java/org/candlepin/insights/exception/mapper/BaseExceptionMapper.java
@@ -1,0 +1,78 @@
+/*
+ * Copyright (c) 2016 - 2019 Red Hat, Inc.
+ *
+ * This software is licensed to you under the GNU General Public License,
+ * version 2 (GPLv2). There is NO WARRANTY for this software, express or
+ * implied, including the implied warranties of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. You should have received a copy of GPLv2
+ * along with this software; if not, see
+ * http://www.gnu.org/licenses/old-licenses/gpl-2.0.txt.
+ *
+ * Red Hat trademarks are not licensed under GPLv2. No permission is
+ * granted to use or replicate Red Hat trademarks that are incorporated
+ * in this software or its documentation.
+ */
+package org.candlepin.insights.exception.mapper;
+
+import org.candlepin.insights.api.model.Error;
+import org.candlepin.insights.api.model.Errors;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.util.ArrayList;
+import java.util.Collections;
+
+import javax.ws.rs.core.Response;
+import javax.ws.rs.ext.ExceptionMapper;
+
+
+/**
+ * The base class for all rhsm-conduit exception mappers. Its intent is to build the same
+ * response no matter the exception.
+ * @param <T> the throwable that is to be mapped
+ */
+public abstract class BaseExceptionMapper<T extends Throwable> implements ExceptionMapper<T> {
+
+    private static final Logger log = LoggerFactory.getLogger(BaseExceptionMapper.class);
+
+    // Media type required per the jsonapi.org API spec. JAXRS doesn't provide
+    // this type as a constant, so we define it ourselves.
+    // TODO We may need to move this media type somewhere common.
+    protected static final String MEDIA_TYPE = "application/vnd.api+json";
+
+    @Override
+    public Response toResponse(T exception) {
+        Error error = buildError(exception);
+        logError(error, exception);
+
+        // IMPL NOTE:
+        //   The jsonapi.org spec requires that an Error response should be a
+        //   collection of Error objects in a dictionary with an 'errors' key
+        //   in case the server should want to return multiple errors in a single
+        //   response. While we likely won't ever need to do this, we'll conform
+        //   to the spec anyhow.
+        Errors errors = new Errors().errors(new ArrayList<>(Collections.singleton(error)));
+        return Response.status(Integer.valueOf(error.getStatus()))
+            .entity(errors)
+            .type(MEDIA_TYPE)
+            .build();
+    }
+
+    /**
+     * Builds an Error model object that will be returned as the body of an
+     * error response.
+     *
+     * @param exception the exception to be transformed.
+     * @return an Error object containing the appropriate code and message
+     *         as deduced from the passed exception.
+     */
+    abstract Error buildError(T exception);
+
+    private void logError(Error error, Throwable exception) {
+        String message = error.getCode() != null && !error.getCode().isEmpty() ?
+            String.format("%s: %s", error.getCode(), error.getTitle()) : error.getTitle();
+        log.error(message, exception);
+    }
+
+}

--- a/src/main/java/org/candlepin/insights/exception/mapper/DefaultExceptionMapper.java
+++ b/src/main/java/org/candlepin/insights/exception/mapper/DefaultExceptionMapper.java
@@ -1,0 +1,43 @@
+/*
+ * Copyright (c) 2009 - 2019 Red Hat, Inc.
+ *
+ * This software is licensed to you under the GNU General Public License,
+ * version 2 (GPLv2). There is NO WARRANTY for this software, express or
+ * implied, including the implied warranties of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. You should have received a copy of GPLv2
+ * along with this software; if not, see
+ * http://www.gnu.org/licenses/old-licenses/gpl-2.0.txt.
+ *
+ * Red Hat trademarks are not licensed under GPLv2. No permission is
+ * granted to use or replicate Red Hat trademarks that are incorporated
+ * in this software or its documentation.
+ */
+package org.candlepin.insights.exception.mapper;
+
+import org.candlepin.insights.api.model.Error;
+import org.candlepin.insights.exception.ErrorCode;
+
+import org.springframework.stereotype.Component;
+
+import javax.ws.rs.core.Response;
+import javax.ws.rs.ext.Provider;
+
+/**
+ * The default exception mapper used to catch any Throwable that isn't already
+ * being mapped by another mapper. This mapper will always produce a 500 HTTP
+ * response containing the message from the exception.
+ */
+@Component
+@Provider
+public class DefaultExceptionMapper extends BaseExceptionMapper<Throwable> {
+
+    @Override
+    protected Error buildError(Throwable exception) {
+        return new Error()
+            .code(ErrorCode.UNHANDLED_EXCEPTION_ERROR.getCode())
+            .status(String.valueOf(Response.Status.INTERNAL_SERVER_ERROR.getStatusCode()))
+            .title("An internal server error has occurred. Check the server logs for further details.")
+            .detail(exception.getMessage());
+    }
+
+}

--- a/src/main/java/org/candlepin/insights/exception/mapper/NotReadyExceptionMapper.java
+++ b/src/main/java/org/candlepin/insights/exception/mapper/NotReadyExceptionMapper.java
@@ -1,0 +1,41 @@
+/*
+ * Copyright (c) 2009 - 2019 Red Hat, Inc.
+ *
+ * This software is licensed to you under the GNU General Public License,
+ * version 2 (GPLv2). There is NO WARRANTY for this software, express or
+ * implied, including the implied warranties of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. You should have received a copy of GPLv2
+ * along with this software; if not, see
+ * http://www.gnu.org/licenses/old-licenses/gpl-2.0.txt.
+ *
+ * Red Hat trademarks are not licensed under GPLv2. No permission is
+ * granted to use or replicate Red Hat trademarks that are incorporated
+ * in this software or its documentation.
+ */
+package org.candlepin.insights.exception.mapper;
+
+import org.candlepin.insights.exception.NotReadyException;
+
+import org.springframework.stereotype.Component;
+
+import javax.ws.rs.core.MediaType;
+import javax.ws.rs.core.Response;
+import javax.ws.rs.core.Response.Status;
+import javax.ws.rs.ext.ExceptionMapper;
+import javax.ws.rs.ext.Provider;
+
+/**
+ * Maps a NotReadyException to a 503 (Service Unavailable) response
+ */
+@Component
+@Provider
+public class NotReadyExceptionMapper implements ExceptionMapper<NotReadyException> {
+    @Override
+    public Response toResponse(NotReadyException exception) {
+        return Response
+            .status(Status.SERVICE_UNAVAILABLE)
+            .entity(exception.getMessage())
+            .type(MediaType.TEXT_PLAIN)
+            .build();
+    }
+}

--- a/src/main/java/org/candlepin/insights/exception/mapper/RhsmConduitExceptionMapper.java
+++ b/src/main/java/org/candlepin/insights/exception/mapper/RhsmConduitExceptionMapper.java
@@ -12,28 +12,25 @@
  * granted to use or replicate Red Hat trademarks that are incorporated
  * in this software or its documentation.
  */
-package org.candlepin.insights.jaxrs;
+package org.candlepin.insights.exception.mapper;
+
+import org.candlepin.insights.api.model.Error;
+import org.candlepin.insights.exception.RhsmConduitException;
 
 import org.springframework.stereotype.Component;
 
-import javax.ws.rs.core.MediaType;
-import javax.ws.rs.core.Response;
-import javax.ws.rs.core.Response.Status;
-import javax.ws.rs.ext.ExceptionMapper;
 import javax.ws.rs.ext.Provider;
 
 /**
- * Maps a NotReadyException to a 503 (Service Unavailable) response
+ * An exception mapper used to map all RhsmConduitExceptions to an error repsonse.
  */
 @Component
 @Provider
-public class NotReadyExceptionMapper implements ExceptionMapper<NotReadyException> {
+public class RhsmConduitExceptionMapper extends BaseExceptionMapper<RhsmConduitException> {
+
     @Override
-    public Response toResponse(NotReadyException exception) {
-        return Response
-            .status(Status.SERVICE_UNAVAILABLE)
-            .entity(exception.getMessage())
-            .type(MediaType.TEXT_PLAIN)
-            .build();
+    protected Error buildError(RhsmConduitException exception) {
+        return exception.error();
     }
+
 }

--- a/src/main/java/org/candlepin/insights/exception/mapper/WebApplicationExceptionMapper.java
+++ b/src/main/java/org/candlepin/insights/exception/mapper/WebApplicationExceptionMapper.java
@@ -1,0 +1,43 @@
+/*
+ * Copyright (c) 2009 - 2019 Red Hat, Inc.
+ *
+ * This software is licensed to you under the GNU General Public License,
+ * version 2 (GPLv2). There is NO WARRANTY for this software, express or
+ * implied, including the implied warranties of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. You should have received a copy of GPLv2
+ * along with this software; if not, see
+ * http://www.gnu.org/licenses/old-licenses/gpl-2.0.txt.
+ *
+ * Red Hat trademarks are not licensed under GPLv2. No permission is
+ * granted to use or replicate Red Hat trademarks that are incorporated
+ * in this software or its documentation.
+ */
+package org.candlepin.insights.exception.mapper;
+
+import org.candlepin.insights.api.model.Error;
+import org.candlepin.insights.exception.ErrorCode;
+
+import org.springframework.stereotype.Component;
+
+import javax.ws.rs.WebApplicationException;
+import javax.ws.rs.ext.Provider;
+
+/**
+ * An exception mapper used to override the default exception mapping done by
+ * resteasy. This implementation generates and returns an Errors object as the
+ * response Json instead of redirecting to an error page.
+ */
+@Component
+@Provider
+public class WebApplicationExceptionMapper extends BaseExceptionMapper<WebApplicationException> {
+
+    @Override
+    protected Error buildError(WebApplicationException wae) {
+        return new Error()
+            .code(ErrorCode.REQUEST_PROCESSING_ERROR.getCode())
+            .status(String.valueOf(wae.getResponse().getStatus()))
+            .title("An rhsm-conduit API error has occurred.")
+            .detail(wae.getMessage());
+    }
+
+}

--- a/src/main/java/org/candlepin/insights/resource/StatusResource.java
+++ b/src/main/java/org/candlepin/insights/resource/StatusResource.java
@@ -18,7 +18,7 @@ import org.candlepin.insights.api.model.Readiness;
 import org.candlepin.insights.api.model.Status;
 import org.candlepin.insights.api.resources.StatusApi;
 import org.candlepin.insights.controller.StatusController;
-import org.candlepin.insights.jaxrs.NotReadyException;
+import org.candlepin.insights.exception.NotReadyException;
 
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;

--- a/src/test/java/org/candlepin/insights/exception/mapper/DefaultExceptionMapperTest.java
+++ b/src/test/java/org/candlepin/insights/exception/mapper/DefaultExceptionMapperTest.java
@@ -1,0 +1,51 @@
+/*
+ * Copyright (c) 2009 - 2019 Red Hat, Inc.
+ *
+ * This software is licensed to you under the GNU General Public License,
+ * version 2 (GPLv2). There is NO WARRANTY for this software, express or
+ * implied, including the implied warranties of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. You should have received a copy of GPLv2
+ * along with this software; if not, see
+ * http://www.gnu.org/licenses/old-licenses/gpl-2.0.txt.
+ *
+ * Red Hat trademarks are not licensed under GPLv2. No permission is
+ * granted to use or replicate Red Hat trademarks that are incorporated
+ * in this software or its documentation.
+ */
+package org.candlepin.insights.exception.mapper;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import org.candlepin.insights.api.model.Error;
+import org.candlepin.insights.api.model.Errors;
+
+import org.junit.jupiter.api.Test;
+
+import javax.ws.rs.core.Response;
+
+
+public class DefaultExceptionMapperTest {
+
+    @Test
+    public void testExceptionMapping() {
+        String expectedDetail = "FORCED!";
+        String expectedTitle =
+            "An internal server error has occurred. Check the server logs for further details.";
+
+        DefaultExceptionMapper mapper = new DefaultExceptionMapper();
+        Response resp = mapper.toResponse(new RuntimeException(expectedDetail));
+
+        Object entityObj = resp.getEntity();
+        assertTrue(entityObj != null && entityObj instanceof Errors);
+
+        Errors errors = (Errors) entityObj;
+        assertEquals(1, errors.getErrors().size());
+
+        Error error = errors.getErrors().get(0);
+        assertEquals("500", error.getStatus());
+        assertEquals(expectedTitle, error.getTitle());
+        assertEquals(expectedDetail, error.getDetail());
+    }
+
+}

--- a/src/test/java/org/candlepin/insights/exception/mapper/RhsmConduitExceptionMapperTest.java
+++ b/src/test/java/org/candlepin/insights/exception/mapper/RhsmConduitExceptionMapperTest.java
@@ -1,0 +1,86 @@
+/*
+ * Copyright (c) 2009 - 2019 Red Hat, Inc.
+ *
+ * This software is licensed to you under the GNU General Public License,
+ * version 2 (GPLv2). There is NO WARRANTY for this software, express or
+ * implied, including the implied warranties of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. You should have received a copy of GPLv2
+ * along with this software; if not, see
+ * http://www.gnu.org/licenses/old-licenses/gpl-2.0.txt.
+ *
+ * Red Hat trademarks are not licensed under GPLv2. No permission is
+ * granted to use or replicate Red Hat trademarks that are incorporated
+ * in this software or its documentation.
+ */
+package org.candlepin.insights.exception.mapper;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+import org.candlepin.insights.api.model.Error;
+import org.candlepin.insights.api.model.Errors;
+import org.candlepin.insights.exception.ErrorCode;
+import org.candlepin.insights.exception.RhsmConduitException;
+import org.candlepin.insights.inventory.client.ApiException;
+
+import org.junit.jupiter.api.Test;
+
+import javax.ws.rs.core.Response;
+import javax.ws.rs.core.Response.Status;
+
+
+public class RhsmConduitExceptionMapperTest {
+
+    @Test
+    public void testMapsRhsmConduitException() {
+        ErrorCode expectedCode = ErrorCode.UNHANDLED_EXCEPTION_ERROR;
+        String expectedCodeString = expectedCode.getCode();
+        Status expectedStatus = Status.INTERNAL_SERVER_ERROR;
+        String expectedTitle = "An exception was thrown";
+        String expectedDetail = "FORCED!";
+
+        RhsmConduitExceptionMapper mapper = new RhsmConduitExceptionMapper();
+        Response resp = mapper.toResponse(new RhsmConduitException(expectedCode, expectedStatus,
+            expectedTitle, expectedDetail));
+
+        Object entityObj = resp.getEntity();
+        assertTrue(entityObj != null && entityObj instanceof Errors);
+
+        Errors errors = (Errors) entityObj;
+        assertEquals(1, errors.getErrors().size());
+
+        Error error = errors.getErrors().get(0);
+        assertEquals(expectedCodeString, error.getCode());
+        assertEquals(String.valueOf(expectedStatus.getStatusCode()), error.getStatus());
+        assertEquals(expectedTitle, error.getTitle());
+        assertEquals(expectedDetail, error.getDetail());
+    }
+
+    @Test
+    public void testMapsNestedException() {
+        ErrorCode expectedCode = ErrorCode.UNHANDLED_EXCEPTION_ERROR;
+        String expectedCodeString = expectedCode.getCode();
+        Status expectedStatus = Status.INTERNAL_SERVER_ERROR;
+        String expectedTitle = "An exception occurred from Inventory API.";
+        String expectedDetail = "Forced API Exception";
+
+        ApiException apie = new ApiException(Status.BAD_REQUEST.getStatusCode(), expectedDetail);
+        RhsmConduitException rhsme = new RhsmConduitException(expectedCode, expectedStatus, expectedTitle,
+            apie);
+
+        RhsmConduitExceptionMapper mapper = new RhsmConduitExceptionMapper();
+        Response resp = mapper.toResponse(rhsme);
+
+        Object entityObj = resp.getEntity();
+        assertTrue(entityObj != null && entityObj instanceof Errors);
+
+        Errors errors = (Errors) entityObj;
+        assertEquals(1, errors.getErrors().size());
+
+        Error error = errors.getErrors().get(0);
+        assertEquals(expectedCodeString, error.getCode());
+        assertEquals(String.valueOf(expectedStatus.getStatusCode()), error.getStatus());
+        assertEquals(expectedTitle, error.getTitle());
+        assertEquals(expectedDetail, error.getDetail());
+    }
+
+}

--- a/src/test/java/org/candlepin/insights/exception/mapper/WebApplicationExceptionMapperTest.java
+++ b/src/test/java/org/candlepin/insights/exception/mapper/WebApplicationExceptionMapperTest.java
@@ -1,0 +1,53 @@
+/*
+ * Copyright (c) 2009 - 2019 Red Hat, Inc.
+ *
+ * This software is licensed to you under the GNU General Public License,
+ * version 2 (GPLv2). There is NO WARRANTY for this software, express or
+ * implied, including the implied warranties of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. You should have received a copy of GPLv2
+ * along with this software; if not, see
+ * http://www.gnu.org/licenses/old-licenses/gpl-2.0.txt.
+ *
+ * Red Hat trademarks are not licensed under GPLv2. No permission is
+ * granted to use or replicate Red Hat trademarks that are incorporated
+ * in this software or its documentation.
+ */
+package org.candlepin.insights.exception.mapper;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import org.candlepin.insights.api.model.Error;
+import org.candlepin.insights.api.model.Errors;
+
+import org.junit.jupiter.api.Test;
+
+import javax.ws.rs.NotFoundException;
+import javax.ws.rs.WebApplicationException;
+import javax.ws.rs.core.Response;
+
+
+public class WebApplicationExceptionMapperTest {
+
+    @Test
+    public void testMapsWebApplicationException() {
+        String expectedDetail = "FORCED!";
+        String expectedTitle = "An rhsm-conduit API error has occurred.";
+
+        WebApplicationException exception = new NotFoundException(expectedDetail);
+
+        WebApplicationExceptionMapper mapper = new WebApplicationExceptionMapper();
+        Response resp = mapper.toResponse(exception);
+        Object entityObj = resp.getEntity();
+        assertTrue(entityObj != null && entityObj instanceof Errors);
+
+        Errors errors = (Errors) entityObj;
+        assertEquals(1, errors.getErrors().size());
+
+        Error error = errors.getErrors().get(0);
+        assertEquals(String.valueOf(exception.getResponse().getStatus()), error.getStatus());
+        assertEquals(expectedTitle, error.getTitle());
+        assertEquals(expectedDetail, error.getDetail());
+    }
+
+}


### PR DESCRIPTION
* Conform to the jsonapi.org API spec
* Renamed the exceptions package to exception
* Moved mappers to exception.mappers
* Moved health check exception and mapper to the exception package
* Added custom exception for external service exceptions.
* Support application codes

## Example JSON error responses
```json
{
    "errors":[
        {
            "status":"500",
            "code":"RHSMCONDUIT201",
            "title":"An error occurred connecting to the inventory service",
            "detail":"RESTEASY004655: Unable to invoke request"}
     ]
}
```
