### PR TITLE
Enable prometheus via micrometer

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -59,12 +59,14 @@ dependencies {
     compile project(":pinhead-client")
     compile "javax.servlet:javax.servlet-api:3.1.0"
     compile "org.jboss.spec.javax.ws.rs:jboss-jaxrs-api_2.1_spec:1.0.2.Final"
+    compile "org.springframework.boot:spring-boot-actuator-autoconfigure:$spring_boot_version"
     compile "org.springframework.boot:spring-boot-autoconfigure:$spring_boot_version"
     compile "org.springframework.boot:spring-boot:$spring_boot_version"
     compile "org.springframework:spring-beans:$spring_version"
     compile "org.springframework:spring-context:$spring_version"
     compile "org.slf4j:slf4j-api:$slf4j_version"
     compile "net.logstash.logback:logstash-logback-encoder:5.3"
+    compile "io.micrometer:micrometer-registry-prometheus:1.1.2"
 
     // Runtime deps that will be included in the result package but not on the compile classpath.  I.e.
     // implementations of APIs we are using.

--- a/build.gradle
+++ b/build.gradle
@@ -64,6 +64,7 @@ dependencies {
     compile "org.springframework.boot:spring-boot:$spring_boot_version"
     compile "org.springframework:spring-beans:$spring_version"
     compile "org.springframework:spring-context:$spring_version"
+    compile "org.springframework:spring-webmvc:$spring_version"
     compile "org.slf4j:slf4j-api:$slf4j_version"
     compile "net.logstash.logback:logstash-logback-encoder:5.3"
     compile "io.micrometer:micrometer-registry-prometheus:1.1.2"

--- a/src/main/java/org/candlepin/insights/metrics/MicrometerUriHackFilter.java
+++ b/src/main/java/org/candlepin/insights/metrics/MicrometerUriHackFilter.java
@@ -1,0 +1,70 @@
+/*
+ * Copyright (c) 2009 - 2019 Red Hat, Inc.
+ *
+ * This software is licensed to you under the GNU General Public License,
+ * version 2 (GPLv2). There is NO WARRANTY for this software, express or
+ * implied, including the implied warranties of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. You should have received a copy of GPLv2
+ * along with this software; if not, see
+ * http://www.gnu.org/licenses/old-licenses/gpl-2.0.txt.
+ *
+ * Red Hat trademarks are not licensed under GPLv2. No permission is
+ * granted to use or replicate Red Hat trademarks that are incorporated
+ * in this software or its documentation.
+ */
+package org.candlepin.insights.metrics;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.stereotype.Component;
+import org.springframework.web.servlet.HandlerMapping;
+
+
+import java.io.IOException;
+import java.nio.file.Paths;
+
+import javax.servlet.http.HttpServletRequest;
+import javax.ws.rs.Path;
+import javax.ws.rs.container.ContainerRequestContext;
+import javax.ws.rs.container.ContainerRequestFilter;
+import javax.ws.rs.container.ResourceInfo;
+import javax.ws.rs.core.Context;
+import javax.ws.rs.core.UriInfo;
+import javax.ws.rs.ext.Provider;
+
+/**
+ * Hack to get URI populated by micrometer.
+ *
+ * This uses internal knowledge of how MVC requests are providing URI to micrometer, found by reading the
+ * source.
+ */
+@Component
+@Provider
+public class MicrometerUriHackFilter implements ContainerRequestFilter {
+
+    private static final Logger log = LoggerFactory.getLogger(MicrometerUriHackFilter.class);
+
+    @Context
+    HttpServletRequest request;
+
+    @Context
+    ResourceInfo resourceInfo;
+
+    @Context
+    UriInfo uriInfo;
+
+    @Override
+    public void filter(ContainerRequestContext requestContext) throws IOException {
+        String path = uriInfo.getAbsolutePath().getPath();
+        try {
+            String applicationPath = uriInfo.getBaseUri().getPath();
+            String classPath = resourceInfo.getResourceClass().getAnnotation(Path.class).value();
+            String methodPath = resourceInfo.getResourceMethod().getAnnotation(Path.class).value();
+            path = Paths.get(applicationPath, classPath, methodPath).toString();
+        }
+        catch (Exception e) {
+            log.debug("Unable to determine templated resource path, falling back to absolute path", e);
+        }
+        request.setAttribute(HandlerMapping.BEST_MATCHING_PATTERN_ATTRIBUTE, path);
+    }
+}

--- a/src/main/resources/application.yaml
+++ b/src/main/resources/application.yaml
@@ -10,6 +10,9 @@ management:
         include:
           - health
           - shutdown
+          - prometheus
   endpoint:
     shutdown:
+      enabled: true
+    prometheus:
       enabled: true


### PR DESCRIPTION
Also, added a hack to populate URI in requests.

After merging, it's possible to see metrics by requesting `/actuator/prometheus`. We get already a lot of statistics for free this way, but future work could use methods described in https://github.com/prometheus/client_java/blob/923d23e33135044b59d1d736ebdfd29154ecca02/README.md#custom-collectors to collect more application-specific information.