### PR TITLE
Revert "Move generated code to isolated sourceSet."

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -82,8 +82,9 @@ dependencies {
 //    testCompile "org.mockito:mockito-core:2.23.4"
 //    testCompile "org.mockito:mockito-junit-jupiter:2.23.4"
 }
-
 project(":api") {
+    // TODO For some reason I can't factor out this projects tasks and just use a subprojects call
+    // to define openApiValidate, generateApiDocs, etc. the same everywhere.
     apply plugin: "org.openapi.generator"
 
     // This project should only contain generated code.  No point in running checkstyle
@@ -122,26 +123,8 @@ project(":api") {
         compile 'io.swagger:swagger-annotations:1.5.21'
     }
 
-    sourceSets {
-        generated {
-            java.srcDir "${buildDir}/generated/src/gen/java"
-        }
-
-        main {
-            compileClasspath += generated.output
-            runtimeClasspath += generated.output
-        }
-
-        test {
-            compileClasspath += generated.output
-            runtimeClasspath += generated.output
-        }
-    }
-
-    compileGeneratedJava.classpath = configurations.compile
-    compileGeneratedJava.dependsOn tasks.openApiGenerate
-    compileJava.dependsOn compileGeneratedJava
-    compileJava.source sourceSets.generated.java, sourceSets.main.java
+    sourceSets.main.java.srcDirs = ["${buildDir}/generated/src/gen/java"]
+    compileJava.dependsOn tasks.openApiGenerate
 }
 
 project(":insights-inventory-client") {
@@ -171,6 +154,9 @@ project(":insights-inventory-client") {
             dateLibrary: "java8"
         ]
     }
+
+    // This project should only contain generated code.  No point in running checkstyle
+    checkstyle.sourceSets = []
 }
 
 project(":pinhead-client") {
@@ -205,9 +191,13 @@ project(":pinhead-client") {
             dateLibrary: "java8"
         ]
     }
+
+    sourceSets.main.java.srcDirs += "${projectDir}/src/main/java"
 }
 
 configure(subprojects.findAll { it.name == 'insights-inventory-client' || it.name == 'pinhead-client'}) {
+    apply plugin: "org.openapi.generator"
+
     openApiValidate {
         inputSpec = api_spec_path
     }
@@ -229,24 +219,6 @@ configure(subprojects.findAll { it.name == 'insights-inventory-client' || it.nam
         compile "com.fasterxml.jackson.core:jackson-annotations:$jackson_version"
     }
 
-    sourceSets {
-        generated {
-            java.srcDir "${buildDir}/generated/src/main/java"
-        }
-
-        main {
-            compileClasspath += generated.output
-            runtimeClasspath += generated.output
-        }
-
-        test {
-            compileClasspath += generated.output
-            runtimeClasspath += generated.output
-        }
-    }
-
-    compileGeneratedJava.classpath = configurations.compile
-    compileGeneratedJava.dependsOn tasks.openApiGenerate
-    compileJava.dependsOn compileGeneratedJava
-    compileJava.source sourceSets.generated.java, sourceSets.main.java
+    sourceSets.main.java.srcDirs = ["${buildDir}/generated/src/main/java"]
+    compileJava.dependsOn tasks.openApiGenerate
 }


### PR DESCRIPTION
This reverts commit 6f76f4a7a5f545b417e2a3a92e100be320d2dc9f.

This was necessary to restore idea compatiblity. I tried a bunch of
other things, including `compile project(path: ':api', configuration: 'generated')`, but no luck.