### PR TITLE
Implemented server content negotiation rules following jsonapi.org

### DIFF
--- a/api/rhsm-conduit-api-spec.yaml
+++ b/api/rhsm-conduit-api-spec.yaml
@@ -40,7 +40,7 @@ paths:
         '200':
           description: 'The request for inventory data was successful.'
           content:
-            application/json:
+            application/vnd.api+json:
               schema:
                 $ref: "#/components/schemas/OrgInventory"
         '400':
@@ -80,7 +80,7 @@ paths:
         '200':
           description: "The request to get the status of the server was successful."
           content:
-            application/json:
+            application/vnd.api+json:
               schema:
                 $ref: "#/components/schemas/Status"
         '500':
@@ -95,7 +95,7 @@ paths:
         '200':
           description: "The request to get the readiness status of the server was successful."
           content:
-            application/json:
+            application/vnd.api+json:
               schema:
                 $ref: "#/components/schemas/Readiness"
         '503':
@@ -106,31 +106,31 @@ components:
     InternalServerError:
       description: "An internal server error has occurred and is not recoverable."
       content:
-        application/json:
+        application/vnd.api+json:
           schema:
             $ref: "#/components/schemas/Error"
     BadRequest:
       description: "The server could could not process the current request."
       content:
-        application/json:
+        application/vnd.api+json:
           schema:
             $ref: "#/components/schemas/Error"
     Forbidden:
       description: "The request was valid, but the request was refused by the server."
       content:
-        application/json:
+        application/vnd.api+json:
           schema:
             $ref: "#/components/schemas/Error"
     ResourceNotFound:
       description: "The requested resource was not found."
       content:
-        application/json:
+        application/vnd.api+json:
           schema:
             $ref: "#/components/schemas/Error"
     ServiceUnavailable:
       description: "The server is currently unavailable."
       content:
-        application/json:
+        application/vnd.api+json:
           schema:
             $ref: "#/components/schemas/Error"
 

--- a/build.gradle
+++ b/build.gradle
@@ -81,8 +81,8 @@ dependencies {
     testCompile "org.springframework:spring-test:$spring_version"
     testCompile "org.junit.jupiter:junit-jupiter-api:$junit_version"
     testRuntime "org.junit.jupiter:junit-jupiter-engine:$junit_version"
+    testCompile "org.mockito:mockito-core:2.23.4"
 
-//    testCompile "org.mockito:mockito-core:2.23.4"
 //    testCompile "org.mockito:mockito-junit-jupiter:2.23.4"
 }
 

--- a/src/main/java/org/candlepin/insights/filter/ContentNegotiationRequestFilter.java
+++ b/src/main/java/org/candlepin/insights/filter/ContentNegotiationRequestFilter.java
@@ -1,0 +1,113 @@
+/*
+ * Copyright (c) 2009 - 2019 Red Hat, Inc.
+ *
+ * This software is licensed to you under the GNU General Public License,
+ * version 2 (GPLv2). There is NO WARRANTY for this software, express or
+ * implied, including the implied warranties of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. You should have received a copy of GPLv2
+ * along with this software; if not, see
+ * http://www.gnu.org/licenses/old-licenses/gpl-2.0.txt.
+ *
+ * Red Hat trademarks are not licensed under GPLv2. No permission is
+ * granted to use or replicate Red Hat trademarks that are incorporated
+ * in this software or its documentation.
+ */
+package org.candlepin.insights.filter;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.stereotype.Component;
+
+import java.util.List;
+import java.util.stream.Collectors;
+
+import javax.ws.rs.NotAcceptableException;
+import javax.ws.rs.NotSupportedException;
+import javax.ws.rs.container.ContainerRequestContext;
+import javax.ws.rs.container.ContainerRequestFilter;
+import javax.ws.rs.container.PreMatching;
+import javax.ws.rs.core.MediaType;
+import javax.ws.rs.ext.Provider;
+
+
+/**
+ * A request filter that ensures that the server follows the content negotiation rules outlined
+ * by jsonapi.org ( https://jsonapi.org/format/#content-negotiation-servers ).
+ */
+@Component
+@Provider
+@PreMatching
+public class ContentNegotiationRequestFilter implements ContainerRequestFilter {
+
+    private static Logger log = LoggerFactory.getLogger(ContentNegotiationRequestFilter.class);
+
+    private static final String APPLICATION_TYPE = "application";
+    private static final String VENDOR_JSON_SUBTYPE = "vnd.api+json";
+    private static final String JSON_MEDIA_TYPE =
+        String.format("%s/%s", APPLICATION_TYPE, VENDOR_JSON_SUBTYPE);
+
+    @Override
+    public void filter(ContainerRequestContext requestContext) {
+        validateApiJsonMediaType(requestContext);
+        validateApiJsonContentType(requestContext);
+    }
+
+    private void validateApiJsonMediaType(ContainerRequestContext requestContext) {
+        /*
+         * IMPL NOTE:
+         *
+         * See https://jsonapi.org/format/#content-negotiation-servers
+         *
+         * Servers MUST respond with a 406 Not Acceptable status code if a request’s Accept header
+         * contains the JSON:API media type and all instances of that media type are modified with
+         * media type parameters.
+         */
+        List<MediaType> matched = findMatchedAcceptedMediaTypes(requestContext);
+
+        // If no accepted media types match, let the default negotiation happen.
+        if (matched.isEmpty()) {
+            return;
+        }
+
+        boolean validFound = matched.stream().anyMatch(x -> x.getParameters().isEmpty());
+        if (!validFound) {
+            throw new NotAcceptableException(
+                String.format("Accept header '%s' can not contain media type parameters.", JSON_MEDIA_TYPE));
+        }
+    }
+
+    private void validateApiJsonContentType(ContainerRequestContext requestContext) {
+        /*
+         * IMPL NOTE:
+         *
+         * See https://jsonapi.org/format/#content-negotiation-servers
+         *
+         * Servers MUST respond with a 415 Unsupported Media Type status code if a request specifies
+         * the header Content-Type: application/vnd.api+json with any media type parameters.
+         */
+        if (!requestContext.getHeaders().containsKey("content-type")) {
+            // Nothing to validate if content-type was not specified.
+            return;
+        }
+
+        String contentTypeHeader = requestContext.getHeaders().getFirst("content-type");
+        MediaType type = contentTypeHeader != null && !contentTypeHeader.isEmpty() ?
+            MediaType.valueOf(contentTypeHeader) : null;
+
+        if (type != null && matchesApplicationJsonApiType(type) && !type.getParameters().isEmpty()) {
+            throw new NotSupportedException(
+                String.format("Parameters not allowed for Content-Type '%s'", JSON_MEDIA_TYPE));
+        }
+    }
+
+    private List<MediaType> findMatchedAcceptedMediaTypes(ContainerRequestContext requestContext) {
+        return requestContext.getAcceptableMediaTypes().stream()
+            .filter(ContentNegotiationRequestFilter::matchesApplicationJsonApiType)
+            .collect(Collectors.toList());
+    }
+
+    private static boolean matchesApplicationJsonApiType(MediaType type) {
+        return APPLICATION_TYPE.equalsIgnoreCase(type.getType()) &&
+            VENDOR_JSON_SUBTYPE.equalsIgnoreCase(type.getSubtype());
+    }
+}

--- a/src/test/java/org/candlepin/insights/filter/ContentNegotiationRequestFilterTest.java
+++ b/src/test/java/org/candlepin/insights/filter/ContentNegotiationRequestFilterTest.java
@@ -1,0 +1,127 @@
+/*
+ * Copyright (c) 2009 - 2019 Red Hat, Inc.
+ *
+ * This software is licensed to you under the GNU General Public License,
+ * version 2 (GPLv2). There is NO WARRANTY for this software, express or
+ * implied, including the implied warranties of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. You should have received a copy of GPLv2
+ * along with this software; if not, see
+ * http://www.gnu.org/licenses/old-licenses/gpl-2.0.txt.
+ *
+ * Red Hat trademarks are not licensed under GPLv2. No permission is
+ * granted to use or replicate Red Hat trademarks that are incorporated
+ * in this software or its documentation.
+ */
+package org.candlepin.insights.filter;
+
+import static org.mockito.Mockito.*;
+import static org.junit.jupiter.api.Assertions.*;
+
+import org.jboss.resteasy.util.MediaTypeHelper;
+import org.junit.jupiter.api.Test;
+
+import java.util.Collections;
+import java.util.List;
+import java.util.stream.Collectors;
+
+import javax.ws.rs.NotAcceptableException;
+import javax.ws.rs.NotSupportedException;
+import javax.ws.rs.container.ContainerRequestContext;
+import javax.ws.rs.core.MediaType;
+import javax.ws.rs.core.MultivaluedHashMap;
+import javax.ws.rs.core.MultivaluedMap;
+
+
+public class ContentNegotiationRequestFilterTest {
+
+    @Test
+    public void acceptHeaderMustContainVendorSpecificJsonHeaderWithNoParameters() throws Exception {
+        List<MediaType> types = MediaTypeHelper.parseHeader("application/vnd.api+json");
+        assertEquals(1, types.size());
+
+        MultivaluedMap<String, String> headers = new MultivaluedHashMap<>();
+        headers.put("content-type", Collections.emptyList());
+
+        ContainerRequestContext requestContext = mock(ContainerRequestContext.class);
+        when(requestContext.getHeaderString(eq("Accept"))).thenReturn(types.get(0).toString());
+        when(requestContext.getAcceptableMediaTypes()).thenReturn(types);
+        when(requestContext.getHeaders()).thenReturn(headers);
+
+        ContentNegotiationRequestFilter filter = new ContentNegotiationRequestFilter();
+        filter.filter(requestContext);
+    }
+
+    @Test
+    public void notAcceptableThrownWhenAcceptHeaderContainsJsonMediaTypeWithParams() {
+        List<MediaType> types = MediaTypeHelper.parseHeader("application/vnd.api+json;version=1.0");
+        assertEquals(1, types.size());
+
+        MultivaluedMap<String, String> headers = new MultivaluedHashMap<>();
+        headers.put("content-type", Collections.emptyList());
+
+        ContainerRequestContext requestContext = mock(ContainerRequestContext.class);
+        when(requestContext.getHeaderString(eq("Accept"))).thenReturn(types.get(0).toString());
+        when(requestContext.getAcceptableMediaTypes()).thenReturn(types);
+        when(requestContext.getHeaders()).thenReturn(headers);
+
+        ContentNegotiationRequestFilter filter = new ContentNegotiationRequestFilter();
+        assertThrows(NotAcceptableException.class, () -> {
+            filter.filter(requestContext);
+        });
+    }
+
+    @Test
+    public void notAcceptableNotThrownWhenAcceptHeaderOneValidJsonMediaTypeWithoutParams() throws Exception {
+        List<MediaType> types = MediaTypeHelper.parseHeader(
+            "application/vnd.api+json;version=1.0,application/vnd.api+json,application/vnd.api+json;v=2");
+        assertEquals(3, types.size());
+
+        MultivaluedMap<String, String> headers = new MultivaluedHashMap<>();
+        headers.put("content-type", Collections.emptyList());
+
+        ContainerRequestContext requestContext = mock(ContainerRequestContext.class);
+        when(requestContext.getHeaderString(eq("Accept"))).thenReturn(types.get(0).toString());
+        when(requestContext.getAcceptableMediaTypes()).thenReturn(types);
+        when(requestContext.getHeaders()).thenReturn(headers);
+
+        ContentNegotiationRequestFilter filter = new ContentNegotiationRequestFilter();
+        filter.filter(requestContext);
+    }
+
+    @Test
+    public void contentTypeHeaderCanNotSpecifyAnyMediaTypeParameters() {
+        List<MediaType> types = MediaTypeHelper.parseHeader("application/vnd.api+json;version=1.0");
+        assertEquals(1, types.size());
+
+        MultivaluedMap<String, String> headers = new MultivaluedHashMap<>();
+        headers.put("content-type", types.stream().map(MediaType::toString).collect(Collectors.toList()));
+
+        ContainerRequestContext requestContext = mock(ContainerRequestContext.class);
+        when(requestContext.getHeaderString(eq("Accept"))).thenReturn(null);
+        when(requestContext.getAcceptableMediaTypes()).thenReturn(Collections.EMPTY_LIST);
+        when(requestContext.getHeaders()).thenReturn(headers);
+
+        ContentNegotiationRequestFilter filter = new ContentNegotiationRequestFilter();
+        assertThrows(NotSupportedException.class, () -> {
+            filter.filter(requestContext);
+        });
+    }
+
+    @Test
+    public void nonMatchingContentTypesCanHaveParamteters() throws Exception {
+        List<MediaType> types = MediaTypeHelper.parseHeader("application/foobar;version=1.0");
+        assertEquals(1, types.size());
+        assertEquals(1, types.get(0).getParameters().size());
+
+        MultivaluedMap<String, String> headers = new MultivaluedHashMap<>();
+        headers.put("content-type", types.stream().map(MediaType::toString).collect(Collectors.toList()));
+
+        ContainerRequestContext requestContext = mock(ContainerRequestContext.class);
+        when(requestContext.getHeaderString(eq("Accept"))).thenReturn(null);
+        when(requestContext.getAcceptableMediaTypes()).thenReturn(Collections.EMPTY_LIST);
+        when(requestContext.getHeaders()).thenReturn(headers);
+
+        ContentNegotiationRequestFilter filter = new ContentNegotiationRequestFilter();
+        filter.filter(requestContext);
+    }
+}


### PR DESCRIPTION
* Updated API schema to support only 'application/vnd.api+json'.
* Added filter to enforce additional content negotiation rules
  1. Servers MUST respond with a 406 Not Acceptable status code if a
     request’s Accept header contains the JSON:API media type and all
     instances of that media type are modified with media type parameters.
  2. Servers MUST respond with a 415 Unsupported Media Type status code if
     a request specifies the Content-Type: application/vnd.api+json with
     any media type parameters.

For more information:
    https://jsonapi.org/format/#content-negotiation-servers

## Testing

Only 'application/vnd.api+json' media types can be accepted.
```bash
$ curl -v -H "Accept: application/json" http://localhost:8080/rhsm-conduit/status
*   Trying ::1...
* TCP_NODELAY set
* Connected to localhost (::1) port 8080 (#0)
> GET /rhsm-conduit/status HTTP/1.1
> Host: localhost:8080
> User-Agent: curl/7.55.1
> Accept: application/json
> 
< HTTP/1.1 406 
< Content-Type: application/vnd.api+json
< Content-Length: 158
< Date: Wed, 13 Feb 2019 14:55:42 GMT
< 
* Connection #0 to host localhost left intact
{"errors":[{"status":"406","code":"RHSMCONDUIT1001","title":"An rhsm-conduit API error has occurred.","detail":"RESTEASY003635: No match for accept header"}]}

# If multiple types are specified in the Accept header, only one of them have to match.
$ curl -v -H "Accept: application/vnd.api+json" -H "Accept: application/json" http://localhost:8080/rhsm-conduit/status
*   Trying ::1...
* TCP_NODELAY set
* Connected to localhost (::1) port 8080 (#0)
> GET /rhsm-conduit/status HTTP/1.1
> Host: localhost:8080
> User-Agent: curl/7.55.1
> Accept: application/vnd.api+json
> Accept: application/json
> 
< HTTP/1.1 200 
< Content-Type: application/vnd.api+json
< Content-Length: 19
< Date: Wed, 13 Feb 2019 14:56:56 GMT
< 
* Connection #0 to host localhost left intact
{"version":"1.0.0"}
```

No parameters are allowed for the 'application/vnd.api+json' accept header.
```bash
$ curl -v -H "Accept: application/vnd.api+json;v=1" http://localhost:8080/rhsm-conduit/status
*   Trying ::1...
* TCP_NODELAY set
* Connected to localhost (::1) port 8080 (#0)
> GET /rhsm-conduit/status HTTP/1.1
> Host: localhost:8080
> User-Agent: curl/7.55.1
> Accept: application/vnd.api+json;v=1
> 
< HTTP/1.1 406 
< Content-Type: application/vnd.api+json
< Content-Length: 195
< Date: Wed, 13 Feb 2019 14:59:33 GMT
< 
* Connection #0 to host localhost left intact
{"errors":[{"status":"406","code":"RHSMCONDUIT1001","title":"An rhsm-conduit API error has occurred.","detail":"Accept header 'application/vnd.api+json' can not contain media type parameters."}]


# Again, only one valid type in the Accept header is required. The other is ignored.
$ curl -v -H "Accept: application/vnd.api+json;v=1" -H "Accept: application/vnd.api+json" http://localhost:8080/rhsm-conduit/status
*   Trying ::1...
* TCP_NODELAY set
* Connected to localhost (::1) port 8080 (#0)
> GET /rhsm-conduit/status HTTP/1.1
> Host: localhost:8080
> User-Agent: curl/7.55.1
> Accept: application/vnd.api+json;v=1
> Accept: application/vnd.api+json
> 
< HTTP/1.1 200 
< Content-Type: application/vnd.api+json
< Content-Length: 19
< Date: Wed, 13 Feb 2019 15:01:34 GMT
< 
* Connection #0 to host localhost left intact
{"version":"1.0.0"}
```

When a content type is specified, it can not contain any media type parameters.
```bash
$ curl -X POST -H "Content-Type: application/vnd.api+json;v=1" http://localhost:8080/rhsm-conduit/inventory/123
{"errors":[{"status":"415","code":"RHSMCONDUIT1001","title":"An rhsm-conduit API error has occurred.","detail":"Parameters not allowed for Content-Type 'application/vnd.api+json'"}]}


```