### PR TITLE
Use Spring's type-safe configuration properties

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -50,7 +50,9 @@ bootJar {
 }
 
 processResources {
-    expand(project.properties)
+    filesMatching("**/application.yaml") {
+        expand(project.properties)
+    }
 }
 
 dependencies {

--- a/openshift/example_config/rhsm-conduit.conf
+++ b/openshift/example_config/rhsm-conduit.conf
@@ -1,1 +1,0 @@
-hostInventoryServiceUrl=localhost

--- a/openshift/example_config/rhsm-conduit.properties
+++ b/openshift/example_config/rhsm-conduit.properties
@@ -1,0 +1,1 @@
+rhsm-conduit.inventory_service.url=localhost

--- a/openshift/template_rhsm-conduit.yaml
+++ b/openshift/template_rhsm-conduit.yaml
@@ -28,7 +28,7 @@ objects:
           name: ${APPLICATION_NAME}
           env:
           - name: JAVA_OPTIONS
-            value: -Dlogging.config=/etc/logback.xml
+            value: -Dlogging.config=/config/logback.xml -Dspring.config.additional-location=file:/config/rhsm-conduit.properties
           livenessProbe:
             failureThreshold: 3
             httpGet:
@@ -54,11 +54,8 @@ objects:
             protocol: TCP
           volumeMounts:
           - name: config
-            mountPath: /etc/rhsm-conduit.conf
-            subPath: rhsm-conduit.conf
-          - name: config
-            mountPath: /etc/logback.xml
-            subPath: logback.xml
+            mountPath: /config
+          workingDir: /
         volumes:
         - name: config
           configMap:

--- a/src/main/java/org/candlepin/insights/ApplicationConfiguration.java
+++ b/src/main/java/org/candlepin/insights/ApplicationConfiguration.java
@@ -16,27 +16,30 @@ package org.candlepin.insights;
 
 import org.candlepin.insights.inventory.client.ApiClientFactory;
 
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.context.properties.EnableConfigurationProperties;
 import org.springframework.boot.web.servlet.ServletContextInitializer;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.context.annotation.PropertySource;
-import org.springframework.core.env.Environment;
 
 import javax.servlet.ServletContext;
 import javax.servlet.ServletException;
 
 /** Class to hold configuration beans */
 @Configuration
-@PropertySource(
-    value = {"classpath:/project.properties", "file:/etc/rhsm-conduit.conf"},
-    ignoreResourceNotFound = true
-)
+@EnableConfigurationProperties(ApplicationProperties.class)
+// The values in application.yaml should already be loaded by default
+@PropertySource("classpath:/rhsm-conduit.properties")
 public class ApplicationConfiguration {
-    @Autowired
-    Environment env;
+    private static final Logger log = LoggerFactory.getLogger(ApplicationConfiguration.class);
 
-    /**
+    @Autowired
+    private ApplicationProperties applicationProperties;
+
+     /**
      * Used to set context-param values since Spring Boot does not have a web.xml.  Technically
      * context-params can be set in application.properties (or application.yaml) with the prefix
      * "server.servlet.context-parameters" but the Spring Boot documentation kind of hides that
@@ -56,6 +59,6 @@ public class ApplicationConfiguration {
 
     @Bean
     public ApiClientFactory hostInventoryClientFactory() {
-        return new ApiClientFactory(env.getProperty("hostInventoryServiceUrl"));
+        return new ApiClientFactory(applicationProperties.getInventoryService().getUrl());
     }
 }

--- a/src/main/java/org/candlepin/insights/ApplicationProperties.java
+++ b/src/main/java/org/candlepin/insights/ApplicationProperties.java
@@ -1,0 +1,56 @@
+/*
+ * Copyright (c) 2009 - 2019 Red Hat, Inc.
+ *
+ * This software is licensed to you under the GNU General Public License,
+ * version 2 (GPLv2). There is NO WARRANTY for this software, express or
+ * implied, including the implied warranties of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. You should have received a copy of GPLv2
+ * along with this software; if not, see
+ * http://www.gnu.org/licenses/old-licenses/gpl-2.0.txt.
+ *
+ * Red Hat trademarks are not licensed under GPLv2. No permission is
+ * granted to use or replicate Red Hat trademarks that are incorporated
+ * in this software or its documentation.
+ */
+package org.candlepin.insights;
+
+import org.candlepin.insights.inventory.client.InventoryService;
+
+import org.springframework.boot.context.properties.ConfigurationProperties;
+import org.springframework.stereotype.Component;
+
+/** POJO to hold property values via Spring's "Type-Safe Configuration Properties" pattern */
+
+@Component
+@ConfigurationProperties(prefix = "rhsm-conduit")
+public class ApplicationProperties {
+    private String version;
+    private final InventoryService inventoryService = new InventoryService();
+
+    public String getVersion() {
+        return version;
+    }
+
+    public void setVersion(String version) {
+        this.version = version;
+    }
+
+    public InventoryService getInventoryService() {
+        return inventoryService;
+    }
+
+    /**
+     * Sub-class for inventory service properties
+     */
+    public static class InventoryService {
+        private String url;
+
+        public String getUrl() {
+            return url;
+        }
+
+        public void setUrl(String url) {
+            this.url = url;
+        }
+    }
+}

--- a/src/main/java/org/candlepin/insights/controller/StatusController.java
+++ b/src/main/java/org/candlepin/insights/controller/StatusController.java
@@ -14,10 +14,11 @@
  */
 package org.candlepin.insights.controller;
 
+import org.candlepin.insights.ApplicationProperties;
 import org.candlepin.insights.api.model.Readiness;
 import org.candlepin.insights.api.model.Status;
 
-import org.springframework.beans.factory.annotation.Value;
+import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Component;
 
 /** Controller use to generate status messages for the StatusResource to use. */
@@ -25,13 +26,12 @@ import org.springframework.stereotype.Component;
 public class StatusController {
     public static final String AVAILABILITY_OK = "OK";
 
-    // Fetches values from the PropertySource defined in ApplicationConfiguration
-    @Value("${application.version}")
-    private String version;
+    @Autowired
+    private ApplicationProperties applicationProperties;
 
     public Status createStatus() {
         Status status = new Status();
-        status.setVersion(version);
+        status.setVersion(applicationProperties.getVersion());
         return status;
     }
 

--- a/src/main/resources/application.yaml
+++ b/src/main/resources/application.yaml
@@ -1,3 +1,8 @@
+# These are core, default properties that we don't want the user to change.  Take care to use
+# spring.config.additional-location instead of spring.config.location so that this file will continue
+# getting loaded.
+# See https://docs.spring.io/spring-boot/docs/current/reference/html/boot-features-external-config.html#boot-features-external-config-application-property-files
+
 resteasy:
   jaxrs:
     app:
@@ -16,3 +21,8 @@ management:
       enabled: true
     prometheus:
       enabled: true
+rhsm-conduit:
+  # If this value doesn't get populated by Gradle filtering, the app won't start due to Spring's expression
+  # language (SPEL) and Gradle's expand method both using the same expansion token.
+  # See https://docs.spring.io/spring-boot/docs/current/reference/html/howto-properties-and-configuration.html#howto-automatic-expansion-gradle
+  version: ${version}

--- a/src/main/resources/project.properties
+++ b/src/main/resources/project.properties
@@ -1,4 +1,0 @@
-# If this value doesn't get populated by Gradle filtering, the app won't start due to Spring's expression
-# language (SPEL) and Gradle's expand method both using the same expansion token.
-# See https://docs.spring.io/spring-boot/docs/current/reference/html/howto-properties-and-configuration.html#howto-automatic-expansion-gradle
-application.version=${version}

--- a/src/main/resources/rhsm-conduit.properties
+++ b/src/main/resources/rhsm-conduit.properties
@@ -1,0 +1,6 @@
+# Place application related defaults here.  This file is loaded via the @PropertySource annotation on the
+# ApplicationConfiguration class.  Prefix properties in this file appropriately (e.g. "rhsm-conduit") so the
+# classes annotated with @ConfigurationProperties will ingest them.
+
+rhsm-conduit.inventory_service.url=localhost
+

--- a/src/test/resources/test.properties
+++ b/src/test/resources/test.properties
@@ -1,2 +1,4 @@
-application.version=TEST
-hostInventoryServiceUrl=https://localhost/api/hostinventory
+# Drop properties we want to load in a test here
+
+rhsm-conduit.version=TEST
+rhsm-conduit.inventory_service.url=https://localhost/api/hostinventory


### PR DESCRIPTION
Using the ConfigurationProperties and EnableConfigurationProperties we
can load values from rhsm-conduit.properties in a type-safe way and then
propagate the values across the application.

See
https://docs.spring.io/spring-boot/docs/current/reference/html/boot-features-external-config.html#boot-features-external-config-typesafe-configuration-properties