### PR TITLE
PinheadApiFactory now delegates to X509ApiClientFactory.

### DIFF
--- a/pinhead-client/src/main/java/org/candlepin/insights/pinhead/client/PinheadApiConfiguration.java
+++ b/pinhead-client/src/main/java/org/candlepin/insights/pinhead/client/PinheadApiConfiguration.java
@@ -15,29 +15,18 @@
 
 package org.candlepin.insights.pinhead.client;
 
-import org.apache.http.conn.ssl.DefaultHostnameVerifier;
-import org.springframework.stereotype.Component;
-
-import java.io.ByteArrayInputStream;
 import java.io.IOException;
 import java.io.InputStream;
-import java.nio.file.Files;
-import java.nio.file.Paths;
 
 import javax.net.ssl.HostnameVerifier;
 
 /**
- * Class to hold values used to build the ApiClient instance wrapped in an SSLContext.
+ * Class to hold values used to build the ApiClient instance wrapped in an SSLContext for Pinhead.
  */
 public class PinheadApiConfiguration {
+    private final X509ApiClientFactoryConfiguration x509Config = new X509ApiClientFactoryConfiguration();
     private boolean useStub;
     private String url;
-    private String keystorePassword;
-    private String keystoreFile;
-    private String truststoreFile;
-    private String truststorePassword;
-
-    private HostnameVerifier hostnameVerifier = new DefaultHostnameVerifier();
 
     public boolean isUseStub() {
         return useStub;
@@ -55,69 +44,59 @@ public class PinheadApiConfiguration {
         this.url = url;
     }
 
+    public X509ApiClientFactoryConfiguration getX509ApiClientFactoryConfiguration() {
+        return x509Config;
+    }
+
     public String getKeystorePassword() {
-        return keystorePassword;
+        return x509Config.getKeystorePassword();
     }
 
     public void setKeystorePassword(String keystorePassword) {
-        this.keystorePassword = keystorePassword;
+        x509Config.setKeystorePassword(keystorePassword);
     }
 
     public String getTruststorePassword() {
-        return truststorePassword;
+        return x509Config.getTruststorePassword();
     }
 
     public void setTruststorePassword(String truststorePassword) {
-        this.truststorePassword = truststorePassword;
+        x509Config.setTruststorePassword(truststorePassword);
     }
 
     public String getKeystoreFile() {
-        return keystoreFile;
+        return x509Config.getKeystoreFile();
     }
 
     public void setKeystoreFile(String keystoreFile) {
-        this.keystoreFile = keystoreFile;
+        x509Config.setKeystoreFile(keystoreFile);
     }
 
     public String getTruststoreFile() {
-        return truststoreFile;
+        return x509Config.getTruststoreFile();
     }
 
     public void setTruststoreFile(String truststoreFile) {
-        this.truststoreFile = truststoreFile;
+        x509Config.setTruststoreFile(truststoreFile);
     }
 
     public InputStream getKeystoreStream() throws IOException {
-        if (keystoreFile == null) {
-            throw new IllegalStateException("No keystore file has been set");
-        }
-        return readStream(keystoreFile);
+        return x509Config.getKeystoreStream();
     }
 
     public InputStream getTruststoreStream() throws IOException {
-        if (truststoreFile == null) {
-            throw new IllegalStateException("No truststore file has been set");
-        }
-        return readStream(truststoreFile);
-    }
-
-    private InputStream readStream(String path) throws IOException {
-        return new ByteArrayInputStream(Files.readAllBytes(Paths.get(path)));
+        return x509Config.getTruststoreStream();
     }
 
     public HostnameVerifier getHostnameVerifier() {
-        return hostnameVerifier;
+        return x509Config.getHostnameVerifier();
     }
 
-    /**
-     * Allow setting the HostnameVerifier implementation.  NoopHostnameVerifier could be used in testing, for
-     * example
-     */
     public void setHostnameVerifier(HostnameVerifier hostnameVerifier) {
-        this.hostnameVerifier = hostnameVerifier;
+        x509Config.setHostnameVerifier(hostnameVerifier);
     }
 
     public boolean usesClientAuth() {
-        return (getKeystoreFile() != null && getKeystorePassword() != null);
+        return x509Config.usesClientAuth();
     }
 }

--- a/pinhead-client/src/main/java/org/candlepin/insights/pinhead/client/StubPinheadApi.java
+++ b/pinhead-client/src/main/java/org/candlepin/insights/pinhead/client/StubPinheadApi.java
@@ -10,6 +10,9 @@ import org.slf4j.LoggerFactory;
 
 import java.util.UUID;
 
+/**
+ * Stub class implementing PinheadApi that we can use for development against if the real thing is unavailable
+ */
 public class StubPinheadApi extends PinheadApi {
     private static Logger log = LoggerFactory.getLogger(StubPinheadApi.class);
 

--- a/pinhead-client/src/main/java/org/candlepin/insights/pinhead/client/X509ApiClientFactory.java
+++ b/pinhead-client/src/main/java/org/candlepin/insights/pinhead/client/X509ApiClientFactory.java
@@ -1,0 +1,97 @@
+/*
+ * Copyright (c) 2009 - 2019 Red Hat, Inc.
+ *
+ * This software is licensed to you under the GNU General Public License,
+ * version 2 (GPLv2). There is NO WARRANTY for this software, express or
+ * implied, including the implied warranties of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. You should have received a copy of GPLv2
+ * along with this software; if not, see
+ * http://www.gnu.org/licenses/old-licenses/gpl-2.0.txt.
+ *
+ * Red Hat trademarks are not licensed under GPLv2. No permission is
+ * granted to use or replicate Red Hat trademarks that are incorporated
+ * in this software or its documentation.
+ */
+package org.candlepin.insights.pinhead.client;
+
+import org.jboss.logging.Logger;
+import org.jboss.resteasy.client.jaxrs.internal.ClientConfiguration;
+import org.jboss.resteasy.spi.ResteasyProviderFactory;
+import org.springframework.beans.factory.FactoryBean;
+
+import java.io.IOException;
+import java.security.GeneralSecurityException;
+import java.security.KeyStore;
+import java.security.KeyStoreException;
+import java.security.NoSuchAlgorithmException;
+
+import javax.net.ssl.KeyManager;
+import javax.net.ssl.KeyManagerFactory;
+import javax.net.ssl.SSLContext;
+import javax.net.ssl.TrustManagerFactory;
+import javax.ws.rs.client.Client;
+import javax.ws.rs.client.ClientBuilder;
+
+/**
+ * Extends the generated ApiClient class to allow for X509 Client Certificate authentication
+ */
+public class X509ApiClientFactory implements FactoryBean<ApiClient>  {
+    private final X509ApiClientFactoryConfiguration x509Config;
+
+    public X509ApiClientFactory(X509ApiClientFactoryConfiguration x509Config) {
+        this.x509Config = x509Config;
+    }
+
+    @Override
+    public ApiClient getObject() throws Exception {
+        ApiClient client = Configuration.getDefaultApiClient();
+        client.setHttpClient(buildHttpClient(x509Config, client));
+        return client;
+    }
+
+    @Override
+    public Class<?> getObjectType() {
+        return ApiClient.class;
+    }
+
+    private Client buildHttpClient(X509ApiClientFactoryConfiguration x509Config, ApiClient client)
+        throws GeneralSecurityException {
+        ClientConfiguration clientConfig = new ClientConfiguration(ResteasyProviderFactory.getInstance());
+        clientConfig.register(client.getJSON());
+        if (client.isDebugging()) {
+            clientConfig.register(Logger.class);
+        }
+
+        ClientBuilder builder = ClientBuilder.newBuilder().withConfig(clientConfig);
+        builder.hostnameVerifier(x509Config.getHostnameVerifier());
+
+        try {
+            KeyStore truststore = KeyStore.getInstance(KeyStore.getDefaultType());
+            truststore.load(
+                x509Config.getTruststoreStream(), x509Config.getTruststorePassword().toCharArray()
+            );
+            TrustManagerFactory trustFactory = TrustManagerFactory.getInstance(
+                TrustManagerFactory.getDefaultAlgorithm()
+            );
+            trustFactory.init(truststore);
+
+            KeyManager[] keyManagers = null;
+            if (x509Config.usesClientAuth()) {
+                KeyManagerFactory keyFactory = KeyManagerFactory.getInstance(KeyManagerFactory.getDefaultAlgorithm());
+                KeyStore keystore = KeyStore.getInstance(KeyStore.getDefaultType());
+                keystore.load(x509Config.getKeystoreStream(), x509Config.getKeystorePassword().toCharArray());
+                keyFactory.init(keystore, x509Config.getKeystorePassword().toCharArray());
+                keyManagers = keyFactory.getKeyManagers();
+            }
+
+            SSLContext sslContext = SSLContext.getInstance("TLSv1.2");
+            sslContext.init(keyManagers, trustFactory.getTrustManagers(), null);
+            builder.sslContext(sslContext);
+        }
+        catch (KeyStoreException | NoSuchAlgorithmException | IOException e)  {
+            throw new GeneralSecurityException("Failed to init SSLContext", e);
+        }
+
+        return builder.build();
+    }
+}

--- a/pinhead-client/src/main/java/org/candlepin/insights/pinhead/client/X509ApiClientFactoryConfiguration.java
+++ b/pinhead-client/src/main/java/org/candlepin/insights/pinhead/client/X509ApiClientFactoryConfiguration.java
@@ -1,0 +1,104 @@
+/*
+ * Copyright (c) 2009 - 2019 Red Hat, Inc.
+ *
+ * This software is licensed to you under the GNU General Public License,
+ * version 2 (GPLv2). There is NO WARRANTY for this software, express or
+ * implied, including the implied warranties of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. You should have received a copy of GPLv2
+ * along with this software; if not, see
+ * http://www.gnu.org/licenses/old-licenses/gpl-2.0.txt.
+ *
+ * Red Hat trademarks are not licensed under GPLv2. No permission is
+ * granted to use or replicate Red Hat trademarks that are incorporated
+ * in this software or its documentation.
+ */
+
+package org.candlepin.insights.pinhead.client;
+
+import org.apache.http.conn.ssl.DefaultHostnameVerifier;
+
+import java.io.ByteArrayInputStream;
+import java.io.IOException;
+import java.io.InputStream;
+import java.nio.file.Files;
+import java.nio.file.Paths;
+
+import javax.net.ssl.HostnameVerifier;
+
+/**
+ * Class to hold values used to build the ApiClient instance wrapped in an SSLContext.
+ */
+public class X509ApiClientFactoryConfiguration {
+    private String keystorePassword;
+    private String keystoreFile;
+    private String truststoreFile;
+    private String truststorePassword;
+
+    private HostnameVerifier hostnameVerifier = new DefaultHostnameVerifier();
+
+    public String getKeystorePassword() {
+        return keystorePassword;
+    }
+
+    public void setKeystorePassword(String keystorePassword) {
+        this.keystorePassword = keystorePassword;
+    }
+
+    public String getTruststorePassword() {
+        return truststorePassword;
+    }
+
+    public void setTruststorePassword(String truststorePassword) {
+        this.truststorePassword = truststorePassword;
+    }
+
+    public String getKeystoreFile() {
+        return keystoreFile;
+    }
+
+    public void setKeystoreFile(String keystoreFile) {
+        this.keystoreFile = keystoreFile;
+    }
+
+    public String getTruststoreFile() {
+        return truststoreFile;
+    }
+
+    public void setTruststoreFile(String truststoreFile) {
+        this.truststoreFile = truststoreFile;
+    }
+
+    public InputStream getKeystoreStream() throws IOException {
+        if (keystoreFile == null) {
+            throw new IllegalStateException("No keystore file has been set");
+        }
+        return readStream(keystoreFile);
+    }
+
+    public InputStream getTruststoreStream() throws IOException {
+        if (truststoreFile == null) {
+            throw new IllegalStateException("No truststore file has been set");
+        }
+        return readStream(truststoreFile);
+    }
+
+    private InputStream readStream(String path) throws IOException {
+        return new ByteArrayInputStream(Files.readAllBytes(Paths.get(path)));
+    }
+
+    public HostnameVerifier getHostnameVerifier() {
+        return hostnameVerifier;
+    }
+
+    /**
+     * Allow setting the HostnameVerifier implementation.  NoopHostnameVerifier could be used in testing, for
+     * example
+     */
+    public void setHostnameVerifier(HostnameVerifier hostnameVerifier) {
+        this.hostnameVerifier = hostnameVerifier;
+    }
+
+    public boolean usesClientAuth() {
+        return (getKeystoreFile() != null && getKeystorePassword() != null);
+    }
+}


### PR DESCRIPTION
This patch separates the responsibilities between the PinheadApiFactory
and the X509ApiClientFactory.  The PinheadApiConfiguration delegates to
the X509ApiClientFactoryConfiguration for developer convenience.

---

My goal with this PR is to preserve the X509ApiClientFactory which may be useful in the future.  I want to keep the cert logic separate from the concerns of any specific ApiClient.