### PR TITLE
Fix generateApiDocs tasks

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -122,6 +122,11 @@ project(":api") {
         generatorName = "html"
         inputSpec = api_spec_path
         outputDir = "$buildDir/docs"
+        generateApiDocumentation = true
+        generateModelDocumentation = true
+        generateModelTests = false
+        generateApiTests = false
+        withXml = false
     }
 
     dependencies {
@@ -168,6 +173,11 @@ configure(subprojects.findAll { it.name == 'insights-inventory-client' || it.nam
         generatorName = "html"
         inputSpec = api_spec_path
         outputDir = "$buildDir/docs"
+        generateApiDocumentation = true
+        generateModelDocumentation = true
+        generateModelTests = false
+        generateApiTests = false
+        withXml = false
     }
 
     openApiGenerate {


### PR DESCRIPTION
These properties are supposed to be optional... but they are not.

See related: OpenAPITools/openapi-generator#2185