### PR TITLE
Configure URLs via environment variables (using custom initializer)

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -76,6 +76,7 @@ dependencies {
     compile project(":insights-inventory-client")
     compile project(":pinhead-client")
     compile "javax.servlet:javax.servlet-api:3.1.0"
+    compile "org.jboss.resteasy:resteasy-spring-boot-starter:3.0.0.Final"
     compile "org.jboss.spec.javax.ws.rs:jboss-jaxrs-api_2.1_spec:1.0.2.Final"
     compile "org.springframework.boot:spring-boot-actuator-autoconfigure:$spring_boot_version"
     compile "org.springframework.boot:spring-boot-autoconfigure:$spring_boot_version"
@@ -90,7 +91,6 @@ dependencies {
     // Runtime deps that will be included in the result package but not on the compile classpath.  I.e.
     // implementations of APIs we are using.
     runtime "ch.qos.logback:logback-classic:1.2.3"
-    runtime "org.jboss.resteasy:resteasy-spring-boot-starter:3.0.0.Final"
     runtime "org.jboss.resteasy:resteasy-jaxrs:$resteasy_version"
     runtime "org.jboss.resteasy:resteasy-validator-provider-11:$resteasy_version"
     runtime "org.hibernate.validator:hibernate-validator:6.0.14.Final"

--- a/openshift/example_config/rhsm-conduit.properties
+++ b/openshift/example_config/rhsm-conduit.properties
@@ -1,3 +1,6 @@
+# override default for PATH_PREFIX
+server.servlet.context-path=${PATH_PREFIX:/r/insights/platform}
+
 # inventory service options
 rhsm-conduit.inventory-service.url=localhost
 # rhsm-conduit.inventory-service.use-stub=false

--- a/openshift/template_rhsm-conduit.yaml
+++ b/openshift/template_rhsm-conduit.yaml
@@ -35,7 +35,7 @@ objects:
               command:
                 - /usr/bin/curl
                 - '-s'
-                - 'http://localhost:8080/${PATH_PREFIX:-/r/insights/platform}/${APP_NAME:-rhsm-conduit}/status'
+                - 'http://localhost:8080/${PATH_PREFIX:-/r/insights/platform}/${APP_NAME:-rhsm-conduit}/v1/status'
             initialDelaySeconds: 10
             periodSeconds: 10
             successThreshold: 1
@@ -46,7 +46,7 @@ objects:
               command:
                 - /usr/bin/curl
                 - '-s'
-                - 'http://localhost:8080/${PATH_PREFIX:-/r/insights/platform}/${APP_NAME:-rhsm-conduit}/status/ready'
+                - 'http://localhost:8080/${PATH_PREFIX:-/r/insights/platform}/${APP_NAME:-rhsm-conduit}/v1/status/ready'
             initialDelaySeconds: 20
             periodSeconds: 10
             successThreshold: 1

--- a/openshift/template_rhsm-conduit.yaml
+++ b/openshift/template_rhsm-conduit.yaml
@@ -31,20 +31,22 @@ objects:
             value: -Dlogging.config=/config/logback.xml -Dspring.config.additional-location=file:/config/rhsm-conduit.properties
           livenessProbe:
             failureThreshold: 3
-            httpGet:
-              path: /rhsm-conduit/status
-              port: 8080
-              scheme: HTTP
+            exec:
+              command:
+                - /usr/bin/curl
+                - '-s'
+                - 'http://localhost:8080/${PATH_PREFIX:-/r/insights/platform}/rhsm-conduit/status'
             initialDelaySeconds: 10
             periodSeconds: 10
             successThreshold: 1
             timeoutSeconds: 3
           readinessProbe:
             failureThreshold: 3
-            httpGet:
-              path: /rhsm-conduit/status/ready
-              port: 8080
-              scheme: HTTP
+            exec:
+              command:
+                - /usr/bin/curl
+                - '-s'
+                - 'http://localhost:8080/${PATH_PREFIX:-/r/insights/platform}/rhsm-conduit/status/ready'
             initialDelaySeconds: 20
             periodSeconds: 10
             successThreshold: 1

--- a/openshift/template_rhsm-conduit.yaml
+++ b/openshift/template_rhsm-conduit.yaml
@@ -35,7 +35,7 @@ objects:
               command:
                 - /usr/bin/curl
                 - '-s'
-                - 'http://localhost:8080/${PATH_PREFIX:-/r/insights/platform}/rhsm-conduit/status'
+                - 'http://localhost:8080/${PATH_PREFIX:-/r/insights/platform}/${APP_NAME:-rhsm-conduit}/status'
             initialDelaySeconds: 10
             periodSeconds: 10
             successThreshold: 1
@@ -46,7 +46,7 @@ objects:
               command:
                 - /usr/bin/curl
                 - '-s'
-                - 'http://localhost:8080/${PATH_PREFIX:-/r/insights/platform}/rhsm-conduit/status/ready'
+                - 'http://localhost:8080/${PATH_PREFIX:-/r/insights/platform}/${APP_NAME:-rhsm-conduit}/status/ready'
             initialDelaySeconds: 20
             periodSeconds: 10
             successThreshold: 1

--- a/src/main/java/org/candlepin/insights/ApplicationConfiguration.java
+++ b/src/main/java/org/candlepin/insights/ApplicationConfiguration.java
@@ -20,14 +20,17 @@ import org.candlepin.insights.jackson.ObjectMapperContextResolver;
 import org.candlepin.insights.pinhead.client.PinheadApiConfiguration;
 import org.candlepin.insights.pinhead.client.PinheadApiFactory;
 
+import org.jboss.resteasy.springboot.ResteasyAutoConfiguration;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.beans.factory.config.BeanFactoryPostProcessor;
 import org.springframework.boot.context.properties.ConfigurationProperties;
 import org.springframework.boot.context.properties.EnableConfigurationProperties;
 import org.springframework.boot.web.servlet.ServletContextInitializer;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.context.annotation.Import;
 import org.springframework.context.annotation.PropertySource;
 import org.springframework.validation.beanvalidation.MethodValidationPostProcessor;
 
@@ -36,6 +39,7 @@ import javax.servlet.ServletException;
 
 /** Class to hold configuration beans */
 @Configuration
+@Import(ResteasyAutoConfiguration.class) // needed to be able to reference ResteasyApplicationBuilder
 @EnableConfigurationProperties(ApplicationProperties.class)
 // The values in application.yaml should already be loaded by default
 @PropertySource("classpath:/rhsm-conduit.properties")
@@ -116,4 +120,8 @@ public class ApplicationConfiguration {
         return new ObjectMapperContextResolver(applicationProperties);
     }
 
+    @Bean
+    public static BeanFactoryPostProcessor servletInitializer() {
+        return new JaxrsApplicationServletInitializer();
+    }
 }

--- a/src/main/java/org/candlepin/insights/JaxrsApplication.java
+++ b/src/main/java/org/candlepin/insights/JaxrsApplication.java
@@ -18,12 +18,10 @@ import org.springframework.stereotype.Component;
 
 import java.util.Set;
 
-import javax.ws.rs.ApplicationPath;
 import javax.ws.rs.core.Application;
 
 /** Bootstrapper for RESTEasy. */
 @Component
-@ApplicationPath("/rhsm-conduit")
 public class JaxrsApplication extends Application {
 
     @Override

--- a/src/main/java/org/candlepin/insights/JaxrsApplicationServletInitializer.java
+++ b/src/main/java/org/candlepin/insights/JaxrsApplicationServletInitializer.java
@@ -1,0 +1,88 @@
+/*
+ * Copyright (c) 2009 - 2019 Red Hat, Inc.
+ *
+ * This software is licensed to you under the GNU General Public License,
+ * version 2 (GPLv2). There is NO WARRANTY for this software, express or
+ * implied, including the implied warranties of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. You should have received a copy of GPLv2
+ * along with this software; if not, see
+ * http://www.gnu.org/licenses/old-licenses/gpl-2.0.txt.
+ *
+ * Red Hat trademarks are not licensed under GPLv2. No permission is
+ * granted to use or replicate Red Hat trademarks that are incorporated
+ * in this software or its documentation.
+ */
+package org.candlepin.insights;
+
+import org.jboss.resteasy.springboot.ResteasyApplicationBuilder;
+import org.springframework.beans.BeansException;
+import org.springframework.beans.factory.config.BeanFactoryPostProcessor;
+import org.springframework.beans.factory.config.ConfigurableListableBeanFactory;
+import org.springframework.beans.factory.config.ConstructorArgumentValues;
+import org.springframework.beans.factory.support.BeanDefinitionRegistry;
+import org.springframework.beans.factory.support.GenericBeanDefinition;
+import org.springframework.core.env.ConfigurableEnvironment;
+
+import java.util.Arrays;
+import java.util.Set;
+import java.util.stream.Collectors;
+
+import javax.ws.rs.Path;
+import javax.ws.rs.core.Application;
+import javax.ws.rs.ext.Provider;
+
+/**
+ * Builds the servlet mappings by scanning beans.
+ *
+ * This assumes that the Application's resources and providers are in the same package (or a sub-package).
+ * It uses the name of the Application's package to lookup the URI mapping, looking for a key like:
+ *
+ *     rhsm-conduit.package_uri_mappings.${package_name}=${path}
+ *
+ * This can be used to map multiple different URIs to different JAX-RS applications if we need to in the
+ * future.
+ */
+public class JaxrsApplicationServletInitializer implements BeanFactoryPostProcessor {
+
+    public void postProcessBeanFactory(ConfigurableListableBeanFactory beanFactory) throws BeansException {
+        BeanDefinitionRegistry registry = (BeanDefinitionRegistry) beanFactory;
+        ConfigurableEnvironment env = beanFactory.getBean(ConfigurableEnvironment.class);
+        String[] applicationBeanNames = beanFactory.getBeanNamesForType(Application.class);
+        Set<Class<?>> resourceBeanClasses =
+            Arrays.stream(beanFactory.getBeanNamesForAnnotation(Path.class))
+            .map(beanFactory::getType).collect(Collectors.toSet());
+        Set<Class<?>> providerBeanClasses =
+            Arrays.stream(beanFactory.getBeanNamesForAnnotation(Provider.class))
+            .map(beanFactory::getType).collect(Collectors.toSet());
+
+        for (String applicationBeanName : applicationBeanNames) {
+            Class<?> applicationClass = beanFactory.getType(applicationBeanName);
+            String applicationClassName = applicationClass.getCanonicalName();
+            String packageName = applicationClassName.substring(0, applicationClassName.lastIndexOf("."));
+            String propertyName = String.format("rhsm-conduit.package_uri_mappings.%s", packageName);
+            String uri = env.getRequiredProperty(propertyName);
+            Set<Class<?>> resourceClasses = resourceBeanClasses.stream()
+                .filter(clazz -> clazz.getCanonicalName().startsWith(packageName))
+                .collect(Collectors.toSet());
+            Set<Class<?>> providerClasses = providerBeanClasses.stream()
+                .filter(clazz -> clazz.getCanonicalName().startsWith(packageName))
+                .collect(Collectors.toSet());
+
+            GenericBeanDefinition applicationServletBean = new GenericBeanDefinition();
+            applicationServletBean.setFactoryBeanName(ResteasyApplicationBuilder.BEAN_NAME);
+            applicationServletBean.setFactoryMethodName("build");
+
+            ConstructorArgumentValues values = new ConstructorArgumentValues();
+            values.addIndexedArgumentValue(0, applicationClass.getName());
+            values.addIndexedArgumentValue(1, uri);
+            values.addIndexedArgumentValue(2, resourceClasses);
+            values.addIndexedArgumentValue(3, providerClasses);
+            applicationServletBean.setConstructorArgumentValues(values);
+
+            applicationServletBean.setAutowireCandidate(false);
+            applicationServletBean.setScope("singleton");
+
+            registry.registerBeanDefinition(applicationClass.getName(), applicationServletBean);
+        }
+    }
+}

--- a/src/main/resources/rhsm-conduit.properties
+++ b/src/main/resources/rhsm-conduit.properties
@@ -1,4 +1,5 @@
 # Place application related defaults here.  This file is loaded via the @PropertySource annotation on the
 # ApplicationConfiguration class.  Prefix properties in this file appropriately (e.g. "rhsm-conduit") so the
 # classes annotated with @ConfigurationProperties will ingest them.
+server.servlet.context-path=${PATH_PREFIX:}
 rhsm-conduit.prettyPrintJson=false

--- a/src/main/resources/rhsm-conduit.properties
+++ b/src/main/resources/rhsm-conduit.properties
@@ -3,4 +3,4 @@
 # classes annotated with @ConfigurationProperties will ingest them.
 server.servlet.context-path=${PATH_PREFIX:}
 rhsm-conduit.prettyPrintJson=false
-rhsm-conduit.package_uri_mappings.org.candlepin.insights=${APP_NAME:rhsm-conduit}
+rhsm-conduit.package_uri_mappings.org.candlepin.insights=${APP_NAME:rhsm-conduit}/v1

--- a/src/main/resources/rhsm-conduit.properties
+++ b/src/main/resources/rhsm-conduit.properties
@@ -3,3 +3,4 @@
 # classes annotated with @ConfigurationProperties will ingest them.
 server.servlet.context-path=${PATH_PREFIX:}
 rhsm-conduit.prettyPrintJson=false
+rhsm-conduit.package_uri_mappings.org.candlepin.insights=${APP_NAME:rhsm-conduit}


### PR DESCRIPTION
Maps context-path to `$PATH_PREFIX` and application path to `$APP_NAME`, and adjusts the probes accordingly.

Maps application path via a custom property
    
`rhsm-conduit.package_uri_mappings.${package_name}=${path}`
    
e.g.
    
`rhsm-conduit.package_uri_mappings.org.candlepin.insights=${APP_NAME:rhsm-conduit}`
    
We can use this in the future to implement multiple versions in the same JAR if we choose to pursue that.
    
Closes #27 and closes #28, since we should only merge one of these PRs.