### PR TITLE
Change to rolling update strategy

### DIFF
--- a/openshift/template_rhsm-conduit.yaml
+++ b/openshift/template_rhsm-conduit.yaml
@@ -15,7 +15,7 @@ objects:
     selector:
       deploymentconfig: ${APPLICATION_NAME}
     strategy:
-      type: Recreate
+      type: Rolling
     template:
       metadata:
         labels:


### PR DESCRIPTION
Recreate involves downtime, so we should go ahead and switch to rolling.