### PR TITLE
Serve swagger-ui at ${PATH_PREFIX}/api-docs

### DIFF
--- a/api/rhsm-conduit-api-spec.yaml
+++ b/api/rhsm-conduit-api-spec.yaml
@@ -5,7 +5,13 @@ info:
   version: 1.0.0
 
 servers:
-  - url: https://localhost/
+  - url: http://localhost:8080/rhsm-conduit/v1
+  - url: http://localhost:8080/{PATH_PREFIX}/{APP_NAME}/v1
+    variables:
+      PATH_PREFIX:
+        default: r/insights/platform
+      APP_NAME:
+        default: rhsm-conduit
 
 paths:
   /inventories/{org_id}:

--- a/build.gradle
+++ b/build.gradle
@@ -87,6 +87,7 @@ dependencies {
     compile "org.slf4j:slf4j-api:$slf4j_version"
     compile "net.logstash.logback:logstash-logback-encoder:5.3"
     compile "io.micrometer:micrometer-registry-prometheus:1.1.2"
+    compile "org.webjars:swagger-ui:3.20.8"
 
     // Runtime deps that will be included in the result package but not on the compile classpath.  I.e.
     // implementations of APIs we are using.

--- a/src/main/java/org/candlepin/insights/ApplicationConfiguration.java
+++ b/src/main/java/org/candlepin/insights/ApplicationConfiguration.java
@@ -33,6 +33,8 @@ import org.springframework.context.annotation.Configuration;
 import org.springframework.context.annotation.Import;
 import org.springframework.context.annotation.PropertySource;
 import org.springframework.validation.beanvalidation.MethodValidationPostProcessor;
+import org.springframework.web.servlet.config.annotation.ViewControllerRegistry;
+import org.springframework.web.servlet.config.annotation.WebMvcConfigurer;
 
 import javax.servlet.ServletContext;
 import javax.servlet.ServletException;
@@ -43,7 +45,7 @@ import javax.servlet.ServletException;
 @EnableConfigurationProperties(ApplicationProperties.class)
 // The values in application.yaml should already be loaded by default
 @PropertySource("classpath:/rhsm-conduit.properties")
-public class ApplicationConfiguration {
+public class ApplicationConfiguration implements WebMvcConfigurer {
     private static final Logger log = LoggerFactory.getLogger(ApplicationConfiguration.class);
 
     @Autowired
@@ -123,5 +125,11 @@ public class ApplicationConfiguration {
     @Bean
     public static BeanFactoryPostProcessor servletInitializer() {
         return new JaxrsApplicationServletInitializer();
+    }
+
+    @Override
+    public void addViewControllers(ViewControllerRegistry registry) {
+        registry.addViewController("/api-docs").setViewName("redirect:/api-docs/index.html");
+        registry.addViewController("/api-docs/").setViewName("redirect:/api-docs/index.html");
     }
 }

--- a/src/main/resources/static/api-docs/index.html
+++ b/src/main/resources/static/api-docs/index.html
@@ -1,0 +1,33 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8">
+    <title>rhsm-conduit API Docs</title>
+    <link rel="stylesheet" type="text/css" href="../webjars/swagger-ui/3.20.8/swagger-ui.css" >
+  </head>
+
+  <body>
+    <div id="swagger-ui"></div>
+    <script src="../webjars/swagger-ui/3.20.8/swagger-ui-bundle.js"> </script>
+    <script src="../webjars/swagger-ui/3.20.8/swagger-ui-standalone-preset.js"></script>
+    <script>
+    window.onload = function() {
+      // Begin Swagger UI call region
+      const ui = SwaggerUIBundle({
+        url: "../rhsm-conduit/v1/openapi.yaml",
+        dom_id: '#swagger-ui',
+        deepLinking: true,
+        presets: [
+          SwaggerUIBundle.presets.apis,
+          SwaggerUIStandalonePreset
+        ],
+        plugins: [
+          SwaggerUIBundle.plugins.DownloadUrl
+        ],
+        layout: "BaseLayout"
+      })
+      window.ui = ui
+    }
+  </script>
+  </body>
+</html>


### PR DESCRIPTION
So when running without PATH_PREFIX specified, it'll be rooted at
/api-docs.

I adjusted the servers in our API spec to make swagger ui functional
out of the box for demos and such.