### PR TITLE
Created a task framework for performing asynchronous work

### DIFF
--- a/src/main/java/org/candlepin/insights/ApplicationConfiguration.java
+++ b/src/main/java/org/candlepin/insights/ApplicationConfiguration.java
@@ -129,4 +129,5 @@ public class ApplicationConfiguration implements WebMvcConfigurer {
         registry.addViewController("/api-docs").setViewName("redirect:/api-docs/index.html");
         registry.addViewController("/api-docs/").setViewName("redirect:/api-docs/index.html");
     }
+
 }

--- a/src/main/java/org/candlepin/insights/resource/InventoriesResource.java
+++ b/src/main/java/org/candlepin/insights/resource/InventoriesResource.java
@@ -18,6 +18,7 @@ import org.candlepin.insights.api.model.ConsumerInventory;
 import org.candlepin.insights.api.model.OrgInventory;
 import org.candlepin.insights.api.resources.InventoriesApi;
 import org.candlepin.insights.controller.InventoryController;
+import org.candlepin.insights.task.TaskManager;
 
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Component;
@@ -39,6 +40,9 @@ public class InventoriesResource implements InventoriesApi {
     @Autowired
     private InventoryController inventoryController;
 
+    @Autowired
+    private TaskManager tasks;
+
     @Override
     public OrgInventory getInventoryForOrg(@NotNull byte[] xRhIdentity, String orgId) {
         return new OrgInventory().consumerInventories(Collections.singletonList(
@@ -51,6 +55,6 @@ public class InventoriesResource implements InventoriesApi {
 
     @Override
     public void updateInventoryForOrg(@NotNull byte[] xRhIdentity, String orgId) {
-        inventoryController.updateInventoryForOrg(orgId);
+        tasks.updateOrgInventory(orgId);
     }
 }

--- a/src/main/java/org/candlepin/insights/task/Task.java
+++ b/src/main/java/org/candlepin/insights/task/Task.java
@@ -1,0 +1,29 @@
+/*
+ * Copyright (c) 2009 - 2019 Red Hat, Inc.
+ *
+ * This software is licensed to you under the GNU General Public License,
+ * version 2 (GPLv2). There is NO WARRANTY for this software, express or
+ * implied, including the implied warranties of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. You should have received a copy of GPLv2
+ * along with this software; if not, see
+ * http://www.gnu.org/licenses/old-licenses/gpl-2.0.txt.
+ *
+ * Red Hat trademarks are not licensed under GPLv2. No permission is
+ * granted to use or replicate Red Hat trademarks that are incorporated
+ * in this software or its documentation.
+ */
+package org.candlepin.insights.task;
+
+
+/**
+ * Defines a unit of async work that is to be performed by rhsm-conduit. Task instances are built by
+ * the TaskFactory.
+ */
+public interface Task {
+
+    /**
+     * Performs the work defined by a Task instance.
+     */
+    void execute();
+
+}

--- a/src/main/java/org/candlepin/insights/task/TaskDescriptor.java
+++ b/src/main/java/org/candlepin/insights/task/TaskDescriptor.java
@@ -1,0 +1,146 @@
+/*
+ * Copyright (c) 2009 - 2019 Red Hat, Inc.
+ *
+ * This software is licensed to you under the GNU General Public License,
+ * version 2 (GPLv2). There is NO WARRANTY for this software, express or
+ * implied, including the implied warranties of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. You should have received a copy of GPLv2
+ * along with this software; if not, see
+ * http://www.gnu.org/licenses/old-licenses/gpl-2.0.txt.
+ *
+ * Red Hat trademarks are not licensed under GPLv2. No permission is
+ * granted to use or replicate Red Hat trademarks that are incorporated
+ * in this software or its documentation.
+ */
+package org.candlepin.insights.task;
+
+import org.springframework.lang.NonNull;
+
+import java.util.HashMap;
+import java.util.Iterator;
+import java.util.Map;
+import java.util.Map.Entry;
+import java.util.Objects;
+
+
+/**
+ * A TaskDescriptor describes a Task that is to be stored in a TaskQueue and is to be
+ * eventually executed by a TaskWorker.
+ *
+ * When describing a Task that is the be queued, a descriptor must at least define the
+ * task group that a task belongs to, as well as the TaskType of the Task.
+ *
+ * A TaskDescriptor requires two key pieces of data; a groupId and a TaskType.
+ *
+ * A groupId should be specified so that the TaskQueue can use it for task organization within the queue.
+ *
+ * A TaskType should be specified so that the TaskFactory can use it to build an associated Task object
+ * that defines the actual work that is to be done.
+ *
+ * A descriptor can also specify any task arguments to customize task execution.
+ */
+public class TaskDescriptor {
+
+    private final String groupId;
+    private final TaskType type;
+    private Map<String, String> args;
+
+    private TaskDescriptor(TaskDescriptorBuilder builder) {
+        this.groupId = builder.groupId;
+        this.type = builder.type;
+        this.args = builder.args;
+    }
+
+    public String getGroupId() {
+        return groupId;
+    }
+
+    public TaskType getTaskType() {
+        return type;
+    }
+
+    public Map<String, String> getTaskArgs() {
+        return args;
+    }
+
+    public String getArg(String key) {
+        return this.args.get(key);
+    }
+
+    @Override
+    public String toString() {
+        StringBuilder builder = new StringBuilder();
+        builder.append("TaskDescriptor[");
+        builder.append("groupId: " + groupId);
+        builder.append(", taskType: " + type);
+        builder.append(", args: [");
+
+        Iterator<Entry<String, String>> iter = args.entrySet().iterator();
+        while (iter.hasNext()) {
+            Entry<String, String> argEntry = iter.next();
+            builder.append(argEntry.getKey() + ": " + argEntry.getValue());
+
+            if (iter.hasNext()) {
+                builder.append(", ");
+            }
+        }
+        builder.append("]");
+        builder.append("]");
+        return builder.toString();
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) {
+            return true;
+        }
+
+        if (!(o instanceof TaskDescriptor)) {
+            return false;
+        }
+
+        TaskDescriptor that = (TaskDescriptor) o;
+        return Objects.equals(groupId, that.groupId) &&
+            type == that.type &&
+            Objects.equals(args, that.args);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(groupId, type, args);
+    }
+
+    public static TaskDescriptorBuilder builder(TaskType type, String taskGroup) {
+        return new TaskDescriptorBuilder(type, taskGroup);
+    }
+
+    /**
+     * A builder object for building TaskDescriptor objects.
+     */
+    public static class TaskDescriptorBuilder {
+
+        @NonNull
+        private final String groupId;
+
+        @NonNull
+        private final TaskType type;
+
+        private Map<String, String> args;
+
+        private TaskDescriptorBuilder(TaskType type, String groupId) {
+            this.type = type;
+            this.groupId = groupId;
+            this.args = new HashMap<>();
+        }
+
+        public TaskDescriptorBuilder setArg(String name, String value) {
+            this.args.put(name, value);
+            return this;
+        }
+
+        public TaskDescriptor build() {
+            return new TaskDescriptor(this);
+        }
+
+    }
+}

--- a/src/main/java/org/candlepin/insights/task/TaskExecutionException.java
+++ b/src/main/java/org/candlepin/insights/task/TaskExecutionException.java
@@ -1,0 +1,27 @@
+/*
+ * Copyright (c) 2009 - 2019 Red Hat, Inc.
+ *
+ * This software is licensed to you under the GNU General Public License,
+ * version 2 (GPLv2). There is NO WARRANTY for this software, express or
+ * implied, including the implied warranties of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. You should have received a copy of GPLv2
+ * along with this software; if not, see
+ * http://www.gnu.org/licenses/old-licenses/gpl-2.0.txt.
+ *
+ * Red Hat trademarks are not licensed under GPLv2. No permission is
+ * granted to use or replicate Red Hat trademarks that are incorporated
+ * in this software or its documentation.
+ */
+package org.candlepin.insights.task;
+
+
+/**
+ * An exception that is thrown when the TaskWorker fails to execute a given Task.
+ */
+public class TaskExecutionException extends Exception {
+
+    public TaskExecutionException(String message, Throwable cause) {
+        super(message, cause);
+    }
+
+}

--- a/src/main/java/org/candlepin/insights/task/TaskFactory.java
+++ b/src/main/java/org/candlepin/insights/task/TaskFactory.java
@@ -1,0 +1,49 @@
+/*
+ * Copyright (c) 2009 - 2019 Red Hat, Inc.
+ *
+ * This software is licensed to you under the GNU General Public License,
+ * version 2 (GPLv2). There is NO WARRANTY for this software, express or
+ * implied, including the implied warranties of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. You should have received a copy of GPLv2
+ * along with this software; if not, see
+ * http://www.gnu.org/licenses/old-licenses/gpl-2.0.txt.
+ *
+ * Red Hat trademarks are not licensed under GPLv2. No permission is
+ * granted to use or replicate Red Hat trademarks that are incorporated
+ * in this software or its documentation.
+ */
+package org.candlepin.insights.task;
+
+import org.candlepin.insights.controller.InventoryController;
+import org.candlepin.insights.task.tasks.UpdateOrgInventoryTask;
+
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Component;
+
+
+/**
+ * A class responsible for a TaskDescriptor into actual Task instances. Task instances are build via the
+ * build(TaskDescriptor) method. The type of Task that will be built is determined by the descriptor's
+ * TaskType property.
+ */
+@Component
+public class TaskFactory {
+
+    @Autowired
+    private InventoryController inventoryController;
+
+    /**
+     * Builds a Task instance based on the specified TaskDescriptor.
+     *
+     * @param taskDescriptor the task descriptor that is used to customize the Task that is to be created.
+     *
+     * @return the Task defined by the descriptor.
+     */
+    public Task build(TaskDescriptor taskDescriptor) {
+        if (TaskType.UPDATE_ORG_INVENTORY.equals(taskDescriptor.getTaskType())) {
+            return new UpdateOrgInventoryTask(inventoryController, taskDescriptor.getArg("org_id"));
+        }
+        throw new IllegalArgumentException("Could not build task. Unknown task type: " +
+            taskDescriptor.getTaskType());
+    }
+}

--- a/src/main/java/org/candlepin/insights/task/TaskManager.java
+++ b/src/main/java/org/candlepin/insights/task/TaskManager.java
@@ -1,0 +1,49 @@
+/*
+ * Copyright (c) 2009 - 2019 Red Hat, Inc.
+ *
+ * This software is licensed to you under the GNU General Public License,
+ * version 2 (GPLv2). There is NO WARRANTY for this software, express or
+ * implied, including the implied warranties of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. You should have received a copy of GPLv2
+ * along with this software; if not, see
+ * http://www.gnu.org/licenses/old-licenses/gpl-2.0.txt.
+ *
+ * Red Hat trademarks are not licensed under GPLv2. No permission is
+ * granted to use or replicate Red Hat trademarks that are incorporated
+ * in this software or its documentation.
+ */
+package org.candlepin.insights.task;
+
+import org.candlepin.insights.task.queue.TaskQueue;
+
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Component;
+
+
+/**
+ * A TaskManager is an injectable component that is responsible for putting tasks into
+ * the TaskQueue. This is the entry point into the task system. Any class that would like
+ * to initiate a task within conduit, should inject this class and call the appropriate
+ * method.
+ */
+@Component
+public class TaskManager {
+
+    @Autowired
+    TaskQueue queue;
+
+    /**
+     * Initiates a task that will update the inventory of the specified organization's ID.
+     *
+     * @param orgId the ID of the org in which to update.
+     */
+    @SuppressWarnings("indentation")
+    public void updateOrgInventory(String orgId) {
+        queue.enqueue(
+            TaskDescriptor.builder(TaskType.UPDATE_ORG_INVENTORY, TaskQueueConfiguration.TASK_GROUP)
+                .setArg("org_id", orgId)
+                .build()
+        );
+    }
+
+}

--- a/src/main/java/org/candlepin/insights/task/TaskQueueConfiguration.java
+++ b/src/main/java/org/candlepin/insights/task/TaskQueueConfiguration.java
@@ -1,0 +1,52 @@
+/*
+ * Copyright (c) 2009 - 2019 Red Hat, Inc.
+ *
+ * This software is licensed to you under the GNU General Public License,
+ * version 2 (GPLv2). There is NO WARRANTY for this software, express or
+ * implied, including the implied warranties of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. You should have received a copy of GPLv2
+ * along with this software; if not, see
+ * http://www.gnu.org/licenses/old-licenses/gpl-2.0.txt.
+ *
+ * Red Hat trademarks are not licensed under GPLv2. No permission is
+ * granted to use or replicate Red Hat trademarks that are incorporated
+ * in this software or its documentation.
+ */
+package org.candlepin.insights.task;
+
+import org.candlepin.insights.task.queue.TaskQueue;
+import org.candlepin.insights.task.queue.passthrough.PassThroughTaskQueue;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+/**
+ * Instantiates/Configures the TaskQueue implementation that should be used. A bean should
+ * be defined with an appropriate @ConditionalOnProperty annotation that matches a possible
+ * rhsm-conduit.queue=:QUEUE_KEY property.
+ *
+ * If the 'queue' property is not set, the pass-through queue will be used.
+ *
+ * NOTE:
+ * It is important that only one TaskQueue implementation can be returned based on the conditional
+ * annotation.
+ */
+@Configuration
+public class TaskQueueConfiguration {
+
+    private static final Logger log = LoggerFactory.getLogger(TaskQueueConfiguration.class);
+
+    public static final String TASK_GROUP = "rhsm-conduit-tasks";
+
+    @Bean
+    @ConditionalOnProperty(prefix = "rhsm-conduit.tasks", name = "queue", havingValue = "pass-through",
+        matchIfMissing = true)
+    TaskQueue passThroughQueue(TaskWorker worker) {
+        log.info("Configuring a pass-through task queue.");
+        return new PassThroughTaskQueue(worker);
+    }
+
+}

--- a/src/main/java/org/candlepin/insights/task/TaskType.java
+++ b/src/main/java/org/candlepin/insights/task/TaskType.java
@@ -1,0 +1,22 @@
+/*
+ * Copyright (c) 2009 - 2019 Red Hat, Inc.
+ *
+ * This software is licensed to you under the GNU General Public License,
+ * version 2 (GPLv2). There is NO WARRANTY for this software, express or
+ * implied, including the implied warranties of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. You should have received a copy of GPLv2
+ * along with this software; if not, see
+ * http://www.gnu.org/licenses/old-licenses/gpl-2.0.txt.
+ *
+ * Red Hat trademarks are not licensed under GPLv2. No permission is
+ * granted to use or replicate Red Hat trademarks that are incorporated
+ * in this software or its documentation.
+ */
+package org.candlepin.insights.task;
+
+/**
+ * An enumeration representing the types of tasks that can be handled by rhsm-conduit.
+ */
+public enum TaskType {
+    UPDATE_ORG_INVENTORY
+}

--- a/src/main/java/org/candlepin/insights/task/TaskWorker.java
+++ b/src/main/java/org/candlepin/insights/task/TaskWorker.java
@@ -1,0 +1,47 @@
+/*
+ * Copyright (c) 2009 - 2019 Red Hat, Inc.
+ *
+ * This software is licensed to you under the GNU General Public License,
+ * version 2 (GPLv2). There is NO WARRANTY for this software, express or
+ * implied, including the implied warranties of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. You should have received a copy of GPLv2
+ * along with this software; if not, see
+ * http://www.gnu.org/licenses/old-licenses/gpl-2.0.txt.
+ *
+ * Red Hat trademarks are not licensed under GPLv2. No permission is
+ * granted to use or replicate Red Hat trademarks that are incorporated
+ * in this software or its documentation.
+ */
+package org.candlepin.insights.task;
+
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Component;
+
+
+/**
+ * A TaskWorker executes a task when it is notified by a processor that a task was received
+ * from a Queue. The task worker should be added as a listener to a TaskQueue's TaskProcessors.
+ */
+@Component
+public class TaskWorker {
+
+    @Autowired
+    private TaskFactory taskFactory;
+
+    /**
+     * Executes the Task described by the given TaskDescriptor.
+     *
+     * @param taskDescriptor the descriptor for the task to execute.
+     * @throws TaskExecutionException when an error occurs running the Task.
+     */
+    public void executeTask(TaskDescriptor taskDescriptor) throws TaskExecutionException {
+        try {
+            Task toExecute = taskFactory.build(taskDescriptor);
+            toExecute.execute();
+        }
+        catch (Exception e) {
+            throw new TaskExecutionException(String.format("Error executing task: %s", taskDescriptor), e);
+        }
+    }
+
+}

--- a/src/main/java/org/candlepin/insights/task/queue/TaskQueue.java
+++ b/src/main/java/org/candlepin/insights/task/queue/TaskQueue.java
@@ -1,0 +1,31 @@
+/*
+ * Copyright (c) 2009 - 2019 Red Hat, Inc.
+ *
+ * This software is licensed to you under the GNU General Public License,
+ * version 2 (GPLv2). There is NO WARRANTY for this software, express or
+ * implied, including the implied warranties of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. You should have received a copy of GPLv2
+ * along with this software; if not, see
+ * http://www.gnu.org/licenses/old-licenses/gpl-2.0.txt.
+ *
+ * Red Hat trademarks are not licensed under GPLv2. No permission is
+ * granted to use or replicate Red Hat trademarks that are incorporated
+ * in this software or its documentation.
+ */
+package org.candlepin.insights.task.queue;
+
+import org.candlepin.insights.task.TaskDescriptor;
+
+/**
+ * A TaskQueue is responsible for storing tasks until they are processed.
+ */
+public interface TaskQueue {
+
+    /**
+     * Enqueues a task that is to be processed by the registered processor.
+     *
+     * @param taskDescriptor a TaskDescriptor describing the task that is to be processed.
+     */
+    void enqueue(TaskDescriptor taskDescriptor);
+
+}

--- a/src/main/java/org/candlepin/insights/task/queue/passthrough/PassThroughTaskQueue.java
+++ b/src/main/java/org/candlepin/insights/task/queue/passthrough/PassThroughTaskQueue.java
@@ -1,0 +1,50 @@
+/*
+ * Copyright (c) 2009 - 2019 Red Hat, Inc.
+ *
+ * This software is licensed to you under the GNU General Public License,
+ * version 2 (GPLv2). There is NO WARRANTY for this software, express or
+ * implied, including the implied warranties of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. You should have received a copy of GPLv2
+ * along with this software; if not, see
+ * http://www.gnu.org/licenses/old-licenses/gpl-2.0.txt.
+ *
+ * Red Hat trademarks are not licensed under GPLv2. No permission is
+ * granted to use or replicate Red Hat trademarks that are incorporated
+ * in this software or its documentation.
+ */
+package org.candlepin.insights.task.queue.passthrough;
+
+import org.candlepin.insights.task.TaskDescriptor;
+import org.candlepin.insights.task.TaskExecutionException;
+import org.candlepin.insights.task.TaskWorker;
+import org.candlepin.insights.task.queue.TaskQueue;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * A TaskQueue implementation that simply immediately executes a Task as
+ * soon as it is enqueued. On task error, the task is simply discarded.
+ */
+public class PassThroughTaskQueue implements TaskQueue {
+
+    private static final Logger log = LoggerFactory.getLogger(PassThroughTaskQueue.class);
+
+    private TaskWorker worker;
+
+    public PassThroughTaskQueue(TaskWorker worker) {
+        this.worker = worker;
+    }
+
+    @Override
+    public void enqueue(TaskDescriptor taskDescriptor) {
+        // Immediately notify the worker that the task has arrived.
+        try {
+            worker.executeTask(taskDescriptor);
+        }
+        catch (TaskExecutionException e) {
+            log.error("An error occurred running a task.", e);
+        }
+    }
+
+}

--- a/src/main/java/org/candlepin/insights/task/tasks/UpdateOrgInventoryTask.java
+++ b/src/main/java/org/candlepin/insights/task/tasks/UpdateOrgInventoryTask.java
@@ -1,0 +1,45 @@
+/*
+ * Copyright (c) 2006 - 2019 Red Hat, Inc.
+ *
+ * This software is licensed to you under the GNU General Public License,
+ * version 2 (GPLv2). There is NO WARRANTY for this software, express or
+ * implied, including the implied warranties of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. You should have received a copy of GPLv2
+ * along with this software; if not, see
+ * http://www.gnu.org/licenses/old-licenses/gpl-2.0.txt.
+ *
+ * Red Hat trademarks are not licensed under GPLv2. No permission is
+ * granted to use or replicate Red Hat trademarks that are incorporated
+ * in this software or its documentation.
+ */
+package org.candlepin.insights.task.tasks;
+
+import org.candlepin.insights.controller.InventoryController;
+import org.candlepin.insights.task.Task;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+
+/**
+ * A task that retrieves the Consumer data associated with an organization from Pinhead, and sends
+ * that data into the insights host inventory.
+ */
+public class UpdateOrgInventoryTask implements Task {
+
+    private static Logger log = LoggerFactory.getLogger(UpdateOrgInventoryTask.class);
+
+    private String orgId;
+    private InventoryController controller;
+
+    public UpdateOrgInventoryTask(InventoryController controller, String orgId) {
+        this.orgId = orgId;
+        this.controller = controller;
+    }
+
+    @Override
+    public void execute() {
+        log.info("Updating inventory for org: {}", orgId);
+        controller.updateInventoryForOrg(orgId);
+    }
+}

--- a/src/test/java/org/candlepin/insights/task/TaskDescriptorTest.java
+++ b/src/test/java/org/candlepin/insights/task/TaskDescriptorTest.java
@@ -1,0 +1,80 @@
+/*
+ * Copyright (c) 2009 - 2019 Red Hat, Inc.
+ *
+ * This software is licensed to you under the GNU General Public License,
+ * version 2 (GPLv2). There is NO WARRANTY for this software, express or
+ * implied, including the implied warranties of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. You should have received a copy of GPLv2
+ * along with this software; if not, see
+ * http://www.gnu.org/licenses/old-licenses/gpl-2.0.txt.
+ *
+ * Red Hat trademarks are not licensed under GPLv2. No permission is
+ * granted to use or replicate Red Hat trademarks that are incorporated
+ * in this software or its documentation.
+ */
+package org.candlepin.insights.task;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+import org.junit.jupiter.api.Test;
+
+import java.util.Map;
+
+public class TaskDescriptorTest {
+
+    @Test
+    public void testCreation() {
+        String expectedGroupId = "my-group";
+        TaskType expectedTaskType = TaskType.UPDATE_ORG_INVENTORY;
+        String expectedArgKey = "arg1";
+        String expectedArgValue = "arg1-val";
+
+        TaskDescriptor desc = TaskDescriptor.builder(expectedTaskType, expectedGroupId)
+            .setArg(expectedArgKey, expectedArgValue)
+            .build();
+
+        assertEquals(expectedGroupId, desc.getGroupId());
+        assertEquals(expectedTaskType, desc.getTaskType());
+
+        Map<String, String> args = desc.getTaskArgs();
+        assertTrue(args.containsKey(expectedArgKey));
+        assertEquals(expectedArgValue, args.get(expectedArgKey));
+        assertEquals(expectedArgValue, desc.getArg(expectedArgKey));
+    }
+
+    @Test
+    public void testEquality() {
+        TaskDescriptor d1 = TaskDescriptor.builder(TaskType.UPDATE_ORG_INVENTORY, "group1")
+            .setArg("a1", "a1v")
+            .build();
+
+        TaskDescriptor d1Copy = TaskDescriptor.builder(TaskType.UPDATE_ORG_INVENTORY, "group1")
+            .setArg("a1", "a1v")
+            .build();
+        assertEquals(d1, d1Copy);
+
+        TaskDescriptor differentGroup =
+            TaskDescriptor.builder(TaskType.UPDATE_ORG_INVENTORY, "group2").build();
+        assertNotEquals(d1, differentGroup);
+
+        TaskDescriptor nullGroup = TaskDescriptor.builder(TaskType.UPDATE_ORG_INVENTORY, null).build();
+        assertNotEquals(d1, nullGroup);
+
+        TaskDescriptor nullType = TaskDescriptor.builder(null, "group1").build();
+        assertNotEquals(d1, nullGroup);
+
+        TaskDescriptor argsNotEqual = TaskDescriptor.builder(TaskType.UPDATE_ORG_INVENTORY, "group1").build();
+        assertNotEquals(d1, argsNotEqual);
+
+        TaskDescriptor argValueNotEqual = TaskDescriptor.builder(TaskType.UPDATE_ORG_INVENTORY, "group1")
+            .setArg("a1", "a1v_")
+            .build();
+        assertNotEquals(d1, argValueNotEqual);
+
+        TaskDescriptor differentArgs = TaskDescriptor.builder(TaskType.UPDATE_ORG_INVENTORY, "group1")
+            .setArg("a2", "v2")
+            .build();
+        assertNotEquals(d1, differentArgs);
+    }
+
+}

--- a/src/test/java/org/candlepin/insights/task/TaskFactoryTest.java
+++ b/src/test/java/org/candlepin/insights/task/TaskFactoryTest.java
@@ -1,0 +1,45 @@
+/*
+ * Copyright (c) 2009 - 2019 Red Hat, Inc.
+ *
+ * This software is licensed to you under the GNU General Public License,
+ * version 2 (GPLv2). There is NO WARRANTY for this software, express or
+ * implied, including the implied warranties of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. You should have received a copy of GPLv2
+ * along with this software; if not, see
+ * http://www.gnu.org/licenses/old-licenses/gpl-2.0.txt.
+ *
+ * Red Hat trademarks are not licensed under GPLv2. No permission is
+ * granted to use or replicate Red Hat trademarks that are incorporated
+ * in this software or its documentation.
+ */
+package org.candlepin.insights.task;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+import org.candlepin.insights.task.tasks.UpdateOrgInventoryTask;
+
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+
+
+@SpringBootTest
+public class TaskFactoryTest {
+
+    @Autowired
+    private TaskFactory factory;
+
+    @Test
+    public void ensureFactoryBuildsUpdateOrgInventoryTask() {
+        Task task = factory.build(TaskDescriptor.builder(TaskType.UPDATE_ORG_INVENTORY, "my-group").build());
+        assertTrue(task instanceof UpdateOrgInventoryTask);
+    }
+
+    @Test
+    public void ensureIllegalArgumentExceptionWhenTaskTypeIsNull() {
+        assertThrows(IllegalArgumentException.class, () -> {
+            factory.build(TaskDescriptor.builder(null, "my-group").build());
+        });
+
+    }
+}

--- a/src/test/java/org/candlepin/insights/task/TaskManagerTest.java
+++ b/src/test/java/org/candlepin/insights/task/TaskManagerTest.java
@@ -1,0 +1,46 @@
+/*
+ * Copyright (c) 2009 - 2019 Red Hat, Inc.
+ *
+ * This software is licensed to you under the GNU General Public License,
+ * version 2 (GPLv2). There is NO WARRANTY for this software, express or
+ * implied, including the implied warranties of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. You should have received a copy of GPLv2
+ * along with this software; if not, see
+ * http://www.gnu.org/licenses/old-licenses/gpl-2.0.txt.
+ *
+ * Red Hat trademarks are not licensed under GPLv2. No permission is
+ * granted to use or replicate Red Hat trademarks that are incorporated
+ * in this software or its documentation.
+ */
+package org.candlepin.insights.task;
+
+import static org.mockito.BDDMockito.*;
+
+import org.candlepin.insights.task.queue.TaskQueue;
+
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+
+@SpringBootTest
+public class TaskManagerTest {
+
+    @MockBean
+    private TaskQueue queue;
+
+    @Autowired
+    private TaskManager manager;
+
+    @Test
+    public void testUpdateOrgInventory() {
+        String expectedOrg = "my-org";
+        manager.updateOrgInventory(expectedOrg);
+
+        TaskDescriptor expectedTaskDescriptor =
+            TaskDescriptor.builder(TaskType.UPDATE_ORG_INVENTORY, TaskQueueConfiguration.TASK_GROUP)
+            .setArg("org_id", expectedOrg)
+            .build();
+        verify(queue).enqueue(eq(expectedTaskDescriptor));
+    }
+}

--- a/src/test/java/org/candlepin/insights/task/TaskWorkerTest.java
+++ b/src/test/java/org/candlepin/insights/task/TaskWorkerTest.java
@@ -1,0 +1,52 @@
+/*
+ * Copyright (c) 2009 - 2019 Red Hat, Inc.
+ *
+ * This software is licensed to you under the GNU General Public License,
+ * version 2 (GPLv2). There is NO WARRANTY for this software, express or
+ * implied, including the implied warranties of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. You should have received a copy of GPLv2
+ * along with this software; if not, see
+ * http://www.gnu.org/licenses/old-licenses/gpl-2.0.txt.
+ *
+ * Red Hat trademarks are not licensed under GPLv2. No permission is
+ * granted to use or replicate Red Hat trademarks that are incorporated
+ * in this software or its documentation.
+ */
+package org.candlepin.insights.task;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.BDDMockito.*;
+
+import org.junit.jupiter.api.Test;
+import org.mockito.Mock;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+
+@SpringBootTest
+public class TaskWorkerTest {
+
+    @MockBean
+    private TaskFactory factory;
+
+    @Autowired
+    private TaskWorker worker;
+
+    @Mock
+    private Task mockTask;
+
+    @Test
+    public void testExecuteTask() throws Exception {
+        when(factory.build(any(TaskDescriptor.class))).thenReturn(mockTask);
+        worker.executeTask(TaskDescriptor.builder(TaskType.UPDATE_ORG_INVENTORY, "group").build());
+        verify(mockTask).execute();
+    }
+
+    @Test
+    public void testThrowsTaskExecutionExceptionOnTaskFailure() throws Exception {
+        when(factory.build(any(TaskDescriptor.class))).thenReturn(mockTask);
+        doThrow(RuntimeException.class).when(mockTask).execute();
+        assertThrows(TaskExecutionException.class,
+            () -> worker.executeTask(TaskDescriptor.builder(TaskType.UPDATE_ORG_INVENTORY, "group").build()));
+    }
+}

--- a/src/test/java/org/candlepin/insights/task/queue/passthrough/PassThroughTaskQueueTest.java
+++ b/src/test/java/org/candlepin/insights/task/queue/passthrough/PassThroughTaskQueueTest.java
@@ -1,0 +1,56 @@
+/*
+ * Copyright (c) 2009 - 2019 Red Hat, Inc.
+ *
+ * This software is licensed to you under the GNU General Public License,
+ * version 2 (GPLv2). There is NO WARRANTY for this software, express or
+ * implied, including the implied warranties of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. You should have received a copy of GPLv2
+ * along with this software; if not, see
+ * http://www.gnu.org/licenses/old-licenses/gpl-2.0.txt.
+ *
+ * Red Hat trademarks are not licensed under GPLv2. No permission is
+ * granted to use or replicate Red Hat trademarks that are incorporated
+ * in this software or its documentation.
+ */
+package org.candlepin.insights.task.queue.passthrough;
+
+import static org.mockito.BDDMockito.*;
+
+import org.candlepin.insights.task.TaskDescriptor;
+import org.candlepin.insights.task.TaskExecutionException;
+import org.candlepin.insights.task.TaskType;
+import org.candlepin.insights.task.TaskWorker;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.Mockito;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+
+@ExtendWith(MockitoExtension.class)
+public class PassThroughTaskQueueTest {
+
+    @Mock
+    private TaskWorker worker;
+
+    @Test
+    public void ensureTaskIsExecutedImmediately() throws TaskExecutionException {
+        PassThroughTaskQueue queue = new PassThroughTaskQueue(worker);
+        TaskDescriptor expectedTaskDesc =
+            TaskDescriptor.builder(TaskType.UPDATE_ORG_INVENTORY, "my-group").build();
+        queue.enqueue(expectedTaskDesc);
+        Mockito.verify(worker).executeTask(eq(expectedTaskDesc));
+    }
+
+    @Test
+    public void verifyNoExceptionWhenTaskFails() throws Exception {
+        PassThroughTaskQueue queue = new PassThroughTaskQueue(worker);
+        TaskDescriptor expectedTaskDesc =
+            TaskDescriptor.builder(TaskType.UPDATE_ORG_INVENTORY, "my-group").build();
+
+        Mockito.doThrow(TaskExecutionException.class).when(worker).executeTask(eq(expectedTaskDesc));
+        queue.enqueue(expectedTaskDesc);
+        Mockito.verify(worker).executeTask(eq(expectedTaskDesc));
+    }
+}

--- a/src/test/java/org/candlepin/insights/task/tasks/UpdateOrgInventoryTaskTest.java
+++ b/src/test/java/org/candlepin/insights/task/tasks/UpdateOrgInventoryTaskTest.java
@@ -1,0 +1,40 @@
+/*
+ * Copyright (c) 2009 - 2019 Red Hat, Inc.
+ *
+ * This software is licensed to you under the GNU General Public License,
+ * version 2 (GPLv2). There is NO WARRANTY for this software, express or
+ * implied, including the implied warranties of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. You should have received a copy of GPLv2
+ * along with this software; if not, see
+ * http://www.gnu.org/licenses/old-licenses/gpl-2.0.txt.
+ *
+ * Red Hat trademarks are not licensed under GPLv2. No permission is
+ * granted to use or replicate Red Hat trademarks that are incorporated
+ * in this software or its documentation.
+ */
+package org.candlepin.insights.task.tasks;
+
+import static org.mockito.BDDMockito.*;
+
+import org.candlepin.insights.controller.InventoryController;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.Mockito;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+@ExtendWith(MockitoExtension.class)
+public class UpdateOrgInventoryTaskTest {
+
+    @Mock
+    private InventoryController controller;
+
+    @Test
+    public void testExecute() {
+        String expectedOrg = "my-org";
+        UpdateOrgInventoryTask task = new UpdateOrgInventoryTask(controller, expectedOrg);
+        task.execute();
+        Mockito.verify(controller).updateInventoryForOrg(eq(expectedOrg));
+    }
+}


### PR DESCRIPTION
## Usage
All that should be required to use this framework is to autowire a TaskManager where applicable and to call one of its methods to trigger an async task.

```
@Autowired
private TaskManager tasks;

// In your method, use the manager to queue up a task.
tasks.updateOrgInventory(orgId);
```

## Framework Details
This framework is made up of a few key components;
**TaskManager** - All task queuing is done though methods on this class

**TaskDescriptor** - Describes a Task that is to be executed. In the case of Kafka, this will describe the message that is to be stored.

**TaskQueue** - The TaskQueue interface provides a means to implement various queuing implementations. It stores TaskDescriptors that are to be converted to Task objects by the TaskWorker when it executed.

**TaskWorker** - Builds a Task from a TaskDescriptor and executes the task.

**Task** - Represents the actual work that needs to be done.

## Configuration
All available TaskQueue configuration is done based on a configuration
property.

```
rhsm-conduit.tasks.queue=<QUEUE_KEY>
```

By default, a **pass-through** queue is used. This queue simply passes a queued TaskDescriptor
on to the TaskWorker to be executed immediately.

When other queue implementations are created, an application configuration should be created for this queue and all beans should be defined with the appropriate @ConditionalOnProperty annotation that filters on a custom QUEUE_KEY for this type of queue.
```
@Bean
@ConditionalOnProperty(prefix = "rhsm-conduit.tasks", name = "queue", havingValue = "my-cool-queue")
TaskQueue passThroughQueue() {
        log.info("Configuring my cool task queue.");
        return new CoolQueue();
    }
```

Alternatively, if we'd like to keep all queue configurations in the same place, we could define the queue related beans in the TaskQueueConfiguration class with the appropriate conditional annotations.
