### PR TITLE
Correct misleading class names.

### DIFF
--- a/insights-inventory-client/src/main/java/org/candlepin/insights/inventory/client/HostsApiFactory.java
+++ b/insights-inventory-client/src/main/java/org/candlepin/insights/inventory/client/HostsApiFactory.java
@@ -27,22 +27,22 @@ public class HostsApiFactory implements FactoryBean<HostsApi> {
 
     private static Logger log = LoggerFactory.getLogger(HostsApiFactory.class);
 
-    private final InventoryServiceConfiguration config;
+    private final InventoryServiceProperties serviceProperties;
 
-    public HostsApiFactory(InventoryServiceConfiguration config) {
-        this.config = config;
+    public HostsApiFactory(InventoryServiceProperties serviceProperties) {
+        this.serviceProperties = serviceProperties;
     }
 
     @Override
     public HostsApi getObject() throws Exception {
-        if (config.isUseStub()) {
+        if (serviceProperties.isUseStub()) {
             log.info("Using stub host inventory client");
             return new StubHostsApi();
         }
         ApiClient apiClient = new ApiClient();
-        if (config.getUrl() != null) {
-            log.info("Host inventory service URL: {}", config.getUrl());
-            apiClient.setBasePath(config.getUrl());
+        if (serviceProperties.getUrl() != null) {
+            log.info("Host inventory service URL: {}", serviceProperties.getUrl());
+            apiClient.setBasePath(serviceProperties.getUrl());
         }
         else {
             log.warn("Host inventory service URL not set...");

--- a/insights-inventory-client/src/main/java/org/candlepin/insights/inventory/client/InventoryServiceProperties.java
+++ b/insights-inventory-client/src/main/java/org/candlepin/insights/inventory/client/InventoryServiceProperties.java
@@ -17,7 +17,7 @@ package org.candlepin.insights.inventory.client;
 /**
  * Sub-class for inventory service properties
  */
-public class InventoryServiceConfiguration {
+public class InventoryServiceProperties {
     private boolean useStub;
     private String url;
 

--- a/insights-inventory-client/src/test/java/org/candlepin/insights/inventory/client/HostsApiFactoryTest.java
+++ b/insights-inventory-client/src/test/java/org/candlepin/insights/inventory/client/HostsApiFactoryTest.java
@@ -21,7 +21,7 @@ import org.junit.jupiter.api.Test;
 public class HostsApiFactoryTest {
     @Test
     public void testStubClientConfiguration() throws Exception {
-        InventoryServiceConfiguration config = new InventoryServiceConfiguration();
+        InventoryServiceProperties config = new InventoryServiceProperties();
         config.setUseStub(true);
         HostsApiFactory factory = new HostsApiFactory(config);
         assertEquals(StubHostsApi.class, factory.getObject().getClass());
@@ -29,7 +29,7 @@ public class HostsApiFactoryTest {
 
     @Test
     public void testClientGetsUrlFromConfiguration() throws Exception {
-        InventoryServiceConfiguration config = new InventoryServiceConfiguration();
+        InventoryServiceProperties config = new InventoryServiceProperties();
         config.setUrl("http://example.com/foobar");
         HostsApiFactory factory = new HostsApiFactory(config);
         assertEquals("http://example.com/foobar", factory.getObject().getApiClient().getBasePath());

--- a/pinhead-client/src/main/java/org/candlepin/insights/pinhead/client/PinheadApiFactory.java
+++ b/pinhead-client/src/main/java/org/candlepin/insights/pinhead/client/PinheadApiFactory.java
@@ -22,36 +22,36 @@ import org.springframework.beans.factory.FactoryBean;
 
 /**
  * Builds a PinheadApi, which may be a stub, or a normal client, with or without cert auth depending on
- * config.
+ * properties.
  */
 public class PinheadApiFactory implements FactoryBean<PinheadApi> {
     private static Logger log = LoggerFactory.getLogger(PinheadApiFactory.class);
 
-    private final PinheadApiConfiguration config;
+    private final PinheadApiProperties properties;
 
-    public PinheadApiFactory(PinheadApiConfiguration config) {
-        this.config = config;
+    public PinheadApiFactory(PinheadApiProperties properties) {
+        this.properties = properties;
     }
 
     @Override
     public PinheadApi getObject() throws Exception {
-        if (config.isUseStub()) {
+        if (properties.isUseStub()) {
             log.info("Using stub pinhead client");
             return new StubPinheadApi();
         }
 
         ApiClient client;
-        if (config.usesClientAuth()) {
+        if (properties.usesClientAuth()) {
             log.info("Pinhead client configured with client-cert auth");
-            client = new X509ApiClientFactory(config.getX509ApiClientFactoryConfiguration()).getObject();
+            client = new X509ApiClientFactory(properties.getX509ApiClientFactoryConfiguration()).getObject();
         }
         else {
             log.info("Pinhead client configured without client-cert auth");
             client = new ApiClient();
         }
-        if (config.getUrl() != null) {
-            log.info("Pinhead URL: {}", config.getUrl());
-            client.setBasePath(config.getUrl());
+        if (properties.getUrl() != null) {
+            log.info("Pinhead URL: {}", properties.getUrl());
+            client.setBasePath(properties.getUrl());
         }
         else {
             log.warn("Pinhead URL not set...");

--- a/pinhead-client/src/main/java/org/candlepin/insights/pinhead/client/PinheadApiProperties.java
+++ b/pinhead-client/src/main/java/org/candlepin/insights/pinhead/client/PinheadApiProperties.java
@@ -23,7 +23,7 @@ import javax.net.ssl.HostnameVerifier;
 /**
  * Class to hold values used to build the ApiClient instance wrapped in an SSLContext for Pinhead.
  */
-public class PinheadApiConfiguration {
+public class PinheadApiProperties {
     private final X509ApiClientFactoryConfiguration x509Config = new X509ApiClientFactoryConfiguration();
     private boolean useStub;
     private String url;

--- a/pinhead-client/src/test/java/org/candlepin/insights/pinhead/client/PinheadApiFactoryTest.java
+++ b/pinhead-client/src/test/java/org/candlepin/insights/pinhead/client/PinheadApiFactoryTest.java
@@ -39,7 +39,7 @@ public class PinheadApiFactoryTest {
     public static final String STORE_PASSWORD = "password";
 
     private WireMockServer server;
-    private PinheadApiConfiguration config;
+    private PinheadApiProperties config;
     private X509ApiClientFactory x509Factory;
 
     private MappingBuilder stubHelloWorld() {
@@ -57,7 +57,7 @@ public class PinheadApiFactoryTest {
 
     @BeforeEach
     private void setUp() {
-        config = new PinheadApiConfiguration();
+        config = new PinheadApiProperties();
     }
 
     @Test

--- a/src/main/java/org/candlepin/insights/ApplicationConfiguration.java
+++ b/src/main/java/org/candlepin/insights/ApplicationConfiguration.java
@@ -15,10 +15,10 @@
 package org.candlepin.insights;
 
 import org.candlepin.insights.inventory.client.HostsApiFactory;
-import org.candlepin.insights.inventory.client.InventoryServiceConfiguration;
+import org.candlepin.insights.inventory.client.InventoryServiceProperties;
 import org.candlepin.insights.jackson.ObjectMapperContextResolver;
-import org.candlepin.insights.pinhead.client.PinheadApiConfiguration;
 import org.candlepin.insights.pinhead.client.PinheadApiFactory;
+import org.candlepin.insights.pinhead.client.PinheadApiProperties;
 
 import org.jboss.resteasy.springboot.ResteasyAutoConfiguration;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -78,30 +78,30 @@ public class ApplicationConfiguration implements WebMvcConfigurer {
      */
     @Bean
     @ConfigurationProperties(prefix = "rhsm-conduit.pinhead")
-    public PinheadApiConfiguration pinheadApiConfiguration() {
-        return new PinheadApiConfiguration();
+    public PinheadApiProperties pinheadApiProperties() {
+        return new PinheadApiProperties();
     }
 
     /**
      * Build the BeanFactory implementation ourselves since the docs say "Implementations are not supposed
      * to rely on annotation-driven injection or other reflective facilities."
-     * @param conf containing the configuration needed by the factory
+     * @param properties containing the configuration needed by the factory
      * @return a configured PinheadApiFactory
      */
     @Bean
-    public PinheadApiFactory pinheadApiFactory(PinheadApiConfiguration conf) {
-        return new PinheadApiFactory(conf);
+    public PinheadApiFactory pinheadApiFactory(PinheadApiProperties properties) {
+        return new PinheadApiFactory(properties);
     }
 
     @Bean
     @ConfigurationProperties(prefix = "rhsm-conduit.inventory-service")
-    public InventoryServiceConfiguration inventoryServiceConfiguration() {
-        return new InventoryServiceConfiguration();
+    public InventoryServiceProperties inventoryServiceProperties() {
+        return new InventoryServiceProperties();
     }
 
     @Bean
-    public HostsApiFactory hostsApiFactory(InventoryServiceConfiguration conf) {
-        return new HostsApiFactory(conf);
+    public HostsApiFactory hostsApiFactory(InventoryServiceProperties properties) {
+        return new HostsApiFactory(properties);
     }
 
     /**


### PR DESCRIPTION
In the Spring world "Configuration" means bean construction and
"Properties" means settings from the outside world.  These classes were
given a misleading name.