### PR TITLE
Updates to address changes in the insights-inventory API

### DIFF
--- a/insights-inventory-client/src/main/java/org/candlepin/insights/inventory/client/StubHostsApi.java
+++ b/insights-inventory-client/src/main/java/org/candlepin/insights/inventory/client/StubHostsApi.java
@@ -14,12 +14,14 @@
  */
 package org.candlepin.insights.inventory.client;
 
+import org.candlepin.insights.inventory.client.model.BulkHostOut;
 import org.candlepin.insights.inventory.client.model.Host;
-import org.candlepin.insights.inventory.client.model.HostOut;
 import org.candlepin.insights.inventory.client.resources.HostsApi;
 
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+
+import java.util.List;
 
 /**
  * Stub of the HostsApi that doesn't make requests, for the methods used by rhsm-conduit.
@@ -29,8 +31,8 @@ public class StubHostsApi extends HostsApi {
     private static Logger log = LoggerFactory.getLogger(StubHostsApi.class);
 
     @Override
-    public HostOut apiHostAddHost(byte[] xRhIdentity, Host host) throws ApiException {
-        log.info("Using identity: {}, appending host: {}", xRhIdentity, host);
-        return new HostOut();
+    public BulkHostOut apiHostAddHostList(List<Host> hosts) throws ApiException {
+        log.info("Adding specified hosts to inventory.");
+        return new BulkHostOut();
     }
 }

--- a/src/main/java/org/candlepin/insights/inventory/InventoryService.java
+++ b/src/main/java/org/candlepin/insights/inventory/InventoryService.java
@@ -16,9 +16,9 @@ package org.candlepin.insights.inventory;
 
 import org.candlepin.insights.exception.RhsmConduitException;
 import org.candlepin.insights.exception.inventory.InventoryServiceException;
+import org.candlepin.insights.inventory.client.model.BulkHostOut;
 import org.candlepin.insights.inventory.client.model.FactSet;
 import org.candlepin.insights.inventory.client.model.Host;
-import org.candlepin.insights.inventory.client.model.HostOut;
 import org.candlepin.insights.inventory.client.resources.HostsApi;
 
 import org.springframework.beans.factory.annotation.Autowired;
@@ -44,19 +44,19 @@ public class InventoryService {
     }
 
     // TODO Update the parameters once we know what will be coming from the RHSM service.
-    public HostOut sendHostUpdate(String orgId, ConduitFacts facts)
+    public BulkHostOut sendHostUpdate(String orgId, ConduitFacts facts)
         throws RhsmConduitException {
+
+        List<Host> toSend = new LinkedList<>();
+        toSend.add(createHost(orgId, facts));
+
         try {
-            return hostsInventoryApi.apiHostAddHost(forgeAuthHeader(orgId), createHost(orgId, facts));
+            return hostsInventoryApi.apiHostAddHostList(toSend);
         }
         catch (Exception e) {
             throw new InventoryServiceException(
                 "An error occurred while sending a host update to the inventory service.", e);
         }
-    }
-
-    private byte[] forgeAuthHeader(String accountNumber) {
-        return "b".getBytes();
     }
 
     /**

--- a/src/test/java/org/candlepin/insights/controller/InventoryControllerTest.java
+++ b/src/test/java/org/candlepin/insights/controller/InventoryControllerTest.java
@@ -19,7 +19,7 @@ import static org.mockito.BDDMockito.*;
 
 import org.candlepin.insights.inventory.ConduitFacts;
 import org.candlepin.insights.inventory.InventoryService;
-import org.candlepin.insights.inventory.client.model.HostOut;
+import org.candlepin.insights.inventory.client.model.BulkHostOut;
 import org.candlepin.insights.pinhead.PinheadService;
 import org.candlepin.insights.pinhead.client.model.Consumer;
 import org.candlepin.insights.pinhead.client.model.InstalledProducts;
@@ -54,7 +54,7 @@ public class InventoryControllerTest {
         consumer2.setUuid(uuid2.toString());
         when(pinheadService.getOrganizationConsumers("123")).thenReturn(
             Arrays.asList(consumer1, consumer2));
-        when(inventoryService.sendHostUpdate(anyString(), isNotNull())).thenReturn(new HostOut());
+        when(inventoryService.sendHostUpdate(anyString(), isNotNull())).thenReturn(new BulkHostOut());
         controller.updateInventoryForOrg("123");
         Mockito.verify(inventoryService, times(2)).sendHostUpdate(eq("123"), any());
     }


### PR DESCRIPTION
This DOES NOT include supporting the auth token, but will allow rhsm-conduit to build again.