### PR TITLE
Make pinhead client compatible w/ current impl

### DIFF
--- a/insights-inventory-client/src/main/java/org/candlepin/insights/inventory/client/StubHostsApi.java
+++ b/insights-inventory-client/src/main/java/org/candlepin/insights/inventory/client/StubHostsApi.java
@@ -39,7 +39,7 @@ public class StubHostsApi extends HostsApi {
 
     @Override
     public BulkHostOut apiHostAddHostList(List<CreateHostIn> hosts) throws ApiException {
-        log.info("Adding specified hosts to inventory.");
+        log.info("Adding specified hosts to inventory: {}", hosts);
         BulkHostOut out = new BulkHostOut().total(hosts.size());
         hosts.forEach(h -> {
             BulkHostOutDetails hostOutDetails = new BulkHostOutDetails()

--- a/pinhead-client/pinhead-client-spec.yaml
+++ b/pinhead-client/pinhead-client-spec.yaml
@@ -8,7 +8,7 @@ servers:
   - url: https://localhost/
 
 paths:
-  /owners/{orgId}/consumer_feed:
+  /owners/{orgId}/consumers/feed:
     description: "Consumer operations based on an owner."
     parameters:
       - name: orgId
@@ -100,9 +100,8 @@ components:
           type: integer
           format: int64
         lastCheckin:
-          # TODO Should this be a datetime type instead of a long?
-          type: integer
-          format: int64
+          type: string
+          format: date-time
         consumerType:
           type: string
         installedProducts:
@@ -140,8 +139,7 @@ components:
         productName:
           type: string
         productVersion:
-          type: integer
-          format: int64
+          type: string
 
     Status:
       required:
@@ -184,7 +182,7 @@ components:
       properties:
         status:
           $ref: "#/components/schemas/Status"
-        consumers:
+        feeds:
           type: array
           items:
             $ref: "#/components/schemas/Consumer"

--- a/pinhead-client/src/main/java/org/candlepin/insights/pinhead/client/PinheadApiFactory.java
+++ b/pinhead-client/src/main/java/org/candlepin/insights/pinhead/client/PinheadApiFactory.java
@@ -58,6 +58,7 @@ public class PinheadApiFactory implements FactoryBean<PinheadApi> {
         if (properties.getUrl() != null) {
             log.info("Pinhead URL: {}", properties.getUrl());
             client.setBasePath(properties.getUrl());
+            client.addDefaultHeader("cp-lookup-permissions", "false");
         }
         else {
             log.warn("Pinhead URL not set...");

--- a/pinhead-client/src/main/java/org/candlepin/insights/pinhead/client/StubPinheadApi.java
+++ b/pinhead-client/src/main/java/org/candlepin/insights/pinhead/client/StubPinheadApi.java
@@ -45,8 +45,8 @@ public class StubPinheadApi extends PinheadApi {
         consumer1.setHypervisorName("hypervisor1.test.com");
         consumer1.getFacts().put("network.fqdn", "host1.test.com");
         consumer1.getFacts().put("dmi.system.uuid", UUID.randomUUID().toString());
-        consumer1.getFacts().put("ip-addresses", "192.168.1.1, 10.0.0.1");
-        consumer1.getFacts().put("mac-addresses", "00:00:00:00:00:00, ff:ff:ff:ff:ff:ff");
+        consumer1.getFacts().put("Ip-addresses", "192.168.1.1, 10.0.0.1");
+        consumer1.getFacts().put("Mac-addresses", "00:00:00:00:00:00, ff:ff:ff:ff:ff:ff");
         consumer1.getFacts().put("cpu.cpu_socket(s)", "2");
         consumer1.getFacts().put("cpu.core(s)_per_socket", "2");
         consumer1.getFacts().put("memory.memtotal", "32757812");
@@ -60,8 +60,8 @@ public class StubPinheadApi extends PinheadApi {
         consumer2.setUuid(UUID.randomUUID().toString());
         consumer2.getFacts().put("network.fqdn", "host2.test.com");
 
-        inventory.getConsumers().add(consumer1);
-        inventory.getConsumers().add(consumer2);
+        inventory.getFeeds().add(consumer1);
+        inventory.getFeeds().add(consumer2);
         log.info("Returning canned pinhead response: {}", inventory);
         return inventory;
     }

--- a/src/main/java/org/candlepin/insights/controller/InventoryController.java
+++ b/src/main/java/org/candlepin/insights/controller/InventoryController.java
@@ -82,16 +82,14 @@ public class InventoryController {
         }
 
         String cpuSockets = pinheadFacts.get("cpu.cpu_socket(s)");
-        Integer numCpuSockets = null;
-        if (!isEmpty(cpuSockets)) {
-            numCpuSockets = Integer.parseInt(cpuSockets);
-            facts.setCpuSockets(numCpuSockets);
-        }
-
         String coresPerSocket = pinheadFacts.get("cpu.core(s)_per_socket");
-        if (!isEmpty(coresPerSocket) && !isEmpty(cpuSockets)) {
-            Integer numCoresPerSocket = Integer.parseInt(coresPerSocket);
-            facts.setCpuCores(numCoresPerSocket * numCpuSockets);
+        if (!isEmpty(cpuSockets)) {
+            Integer numCpuSockets = Integer.parseInt(cpuSockets);
+            facts.setCpuSockets(numCpuSockets);
+            if (!isEmpty(coresPerSocket)) {
+                Integer numCoresPerSocket = Integer.parseInt(coresPerSocket);
+                facts.setCpuCores(numCoresPerSocket * numCpuSockets);
+            }
         }
 
         String memoryTotal = pinheadFacts.get("memory.memtotal");

--- a/src/main/java/org/candlepin/insights/controller/InventoryController.java
+++ b/src/main/java/org/candlepin/insights/controller/InventoryController.java
@@ -59,53 +59,64 @@ public class InventoryController {
         facts.setSubscriptionManagerId(UUID.fromString(consumer.getUuid()));
 
         String systemUuid = consumer.getFacts().get("dmi.system.uuid");
-        if (systemUuid != null) {
+        if (systemUuid != null && !systemUuid.isEmpty()) {
             facts.setBiosUuid(UUID.fromString(systemUuid));
         }
 
-        String ipAddresses = consumer.getFacts().get("ip-addresses");
-        if (ipAddresses != null) {
+        String ipAddresses = consumer.getFacts().get("Ip-addresses");
+        if (ipAddresses != null && !ipAddresses.isEmpty()) {
             String[] ipAddressesSplit = ipAddresses.split(", ");
             facts.setIpAddresses(Arrays.asList(ipAddressesSplit));
         }
 
-        facts.setFqdn(consumer.getFacts().get("network.fqdn"));
+        String fqdn = consumer.getFacts().get("network.fqdn");
+        if (fqdn != null && !fqdn.isEmpty()) {
+            facts.setFqdn(fqdn);
+        }
 
-        String macAddresses = consumer.getFacts().get("mac-addresses");
-        if (macAddresses != null) {
+        String macAddresses = consumer.getFacts().get("Mac-addresses");
+        if (macAddresses != null && !macAddresses.isEmpty()) {
             String[] macAddressesSplit = macAddresses.split(", ");
             facts.setMacAddresses(Arrays.asList(macAddressesSplit));
         }
 
         String cpuSockets = consumer.getFacts().get("cpu.cpu_socket(s)");
         Integer numCpuSockets = null;
-        if (cpuSockets != null) {
+        if (cpuSockets != null && !cpuSockets.isEmpty()) {
             numCpuSockets = Integer.parseInt(cpuSockets);
             facts.setCpuSockets(numCpuSockets);
         }
 
         String coresPerSocket = consumer.getFacts().get("cpu.core(s)_per_socket");
-        if (coresPerSocket != null && cpuSockets != null) {
+        if (coresPerSocket != null && !coresPerSocket.isEmpty() &&
+            cpuSockets != null && !cpuSockets.isEmpty()) {
+
             Integer numCoresPerSocket = Integer.parseInt(coresPerSocket);
             facts.setCpuCores(numCoresPerSocket * numCpuSockets);
         }
 
         String memoryTotal = consumer.getFacts().get("memory.memtotal");
-        if (memoryTotal != null) {
+        if (memoryTotal != null && !memoryTotal.isEmpty()) {
             int memoryBytes = Integer.parseInt(memoryTotal);
             // memtotal is a little less than accessible memory, round up to next GB
             int memoryGigabytes = (int) Math.ceil((float) memoryBytes / (float) KIBIBYTES_PER_GIBIBYTE);
             facts.setMemory(memoryGigabytes);
         }
 
-        facts.setArchitecture(consumer.getFacts().get("uname.machine"));
+        String architecture = consumer.getFacts().get("uname.machine");
+        if (architecture != null && !architecture.isEmpty()) {
+            facts.setArchitecture(architecture);
+        }
 
         String isGuest = consumer.getFacts().get("virt.is_guest");
         if (isGuest != null && !isGuest.equals("Unknown")) {
             facts.setVirtual(isGuest.equals("True"));
         }
 
-        facts.setVmHost(consumer.getHypervisorName());
+        String vmHost = consumer.getHypervisorName();
+        if (vmHost != null && !vmHost.isEmpty()) {
+            facts.setVmHost(vmHost);
+        }
 
         List<String> productIds = consumer.getInstalledProducts().stream()
             .map(installedProduct -> installedProduct.getProductId().toString()).collect(Collectors.toList());

--- a/src/main/java/org/candlepin/insights/controller/InventoryController.java
+++ b/src/main/java/org/candlepin/insights/controller/InventoryController.java
@@ -109,7 +109,7 @@ public class InventoryController {
     private void extractNetworkFacts(Map<String, String> pinheadFacts, ConduitFacts facts) {
         String ipAddresses = pinheadFacts.get("Ip-addresses");
         if (!isEmpty(ipAddresses)) {
-            String[] ipAddressesSplit = ipAddresses.split(", ");
+            String[] ipAddressesSplit = ipAddresses.split(",\\s*");
             facts.setIpAddresses(Arrays.asList(ipAddressesSplit));
         }
 
@@ -120,7 +120,7 @@ public class InventoryController {
 
         String macAddresses = pinheadFacts.get("Mac-addresses");
         if (!isEmpty(macAddresses)) {
-            String[] macAddressesSplit = macAddresses.split(", ");
+            String[] macAddressesSplit = macAddresses.split(",\\s*");
             facts.setMacAddresses(Arrays.asList(macAddressesSplit));
         }
     }
@@ -129,8 +129,8 @@ public class InventoryController {
         ConduitFacts facts) {
 
         String isGuest = pinheadFacts.get("virt.is_guest");
-        if (!isEmpty(isGuest) && !isGuest.equals("Unknown")) {
-            facts.setVirtual(isGuest.equals("True"));
+        if (!isEmpty(isGuest) && !isGuest.equalsIgnoreCase("Unknown")) {
+            facts.setVirtual(isGuest.equalsIgnoreCase("True"));
         }
 
         String vmHost = consumer.getHypervisorName();

--- a/src/main/java/org/candlepin/insights/controller/InventoryController.java
+++ b/src/main/java/org/candlepin/insights/controller/InventoryController.java
@@ -34,6 +34,7 @@ import org.springframework.stereotype.Component;
 import java.util.Arrays;
 import java.util.LinkedList;
 import java.util.List;
+import java.util.Map;
 import java.util.UUID;
 import java.util.stream.Collectors;
 
@@ -53,76 +54,91 @@ public class InventoryController {
     @Autowired
     private PinheadService pinheadService;
 
+    private static boolean isEmpty(String value) {
+        return value == null || value.isEmpty();
+    }
+
     public ConduitFacts getFactsFromConsumer(Consumer consumer) {
+        final Map<String, String> pinheadFacts = consumer.getFacts();
         ConduitFacts facts = new ConduitFacts();
 
         facts.setSubscriptionManagerId(UUID.fromString(consumer.getUuid()));
 
-        String systemUuid = consumer.getFacts().get("dmi.system.uuid");
-        if (systemUuid != null && !systemUuid.isEmpty()) {
-            facts.setBiosUuid(UUID.fromString(systemUuid));
-        }
-
-        String ipAddresses = consumer.getFacts().get("Ip-addresses");
-        if (ipAddresses != null && !ipAddresses.isEmpty()) {
-            String[] ipAddressesSplit = ipAddresses.split(", ");
-            facts.setIpAddresses(Arrays.asList(ipAddressesSplit));
-        }
-
-        String fqdn = consumer.getFacts().get("network.fqdn");
-        if (fqdn != null && !fqdn.isEmpty()) {
-            facts.setFqdn(fqdn);
-        }
-
-        String macAddresses = consumer.getFacts().get("Mac-addresses");
-        if (macAddresses != null && !macAddresses.isEmpty()) {
-            String[] macAddressesSplit = macAddresses.split(", ");
-            facts.setMacAddresses(Arrays.asList(macAddressesSplit));
-        }
-
-        String cpuSockets = consumer.getFacts().get("cpu.cpu_socket(s)");
-        Integer numCpuSockets = null;
-        if (cpuSockets != null && !cpuSockets.isEmpty()) {
-            numCpuSockets = Integer.parseInt(cpuSockets);
-            facts.setCpuSockets(numCpuSockets);
-        }
-
-        String coresPerSocket = consumer.getFacts().get("cpu.core(s)_per_socket");
-        if (coresPerSocket != null && !coresPerSocket.isEmpty() &&
-            cpuSockets != null && !cpuSockets.isEmpty()) {
-
-            Integer numCoresPerSocket = Integer.parseInt(coresPerSocket);
-            facts.setCpuCores(numCoresPerSocket * numCpuSockets);
-        }
-
-        String memoryTotal = consumer.getFacts().get("memory.memtotal");
-        if (memoryTotal != null && !memoryTotal.isEmpty()) {
-            int memoryBytes = Integer.parseInt(memoryTotal);
-            // memtotal is a little less than accessible memory, round up to next GB
-            int memoryGigabytes = (int) Math.ceil((float) memoryBytes / (float) KIBIBYTES_PER_GIBIBYTE);
-            facts.setMemory(memoryGigabytes);
-        }
-
-        String architecture = consumer.getFacts().get("uname.machine");
-        if (architecture != null && !architecture.isEmpty()) {
-            facts.setArchitecture(architecture);
-        }
-
-        String isGuest = consumer.getFacts().get("virt.is_guest");
-        if (isGuest != null && !isGuest.equals("Unknown")) {
-            facts.setVirtual(isGuest.equals("True"));
-        }
-
-        String vmHost = consumer.getHypervisorName();
-        if (vmHost != null && !vmHost.isEmpty()) {
-            facts.setVmHost(vmHost);
-        }
+        extractNetworkFacts(pinheadFacts, facts);
+        extractHardwareFacts(pinheadFacts, facts);
+        extractHypervisorFacts(consumer, pinheadFacts, facts);
 
         List<String> productIds = consumer.getInstalledProducts().stream()
             .map(installedProduct -> installedProduct.getProductId().toString()).collect(Collectors.toList());
         facts.setRhProd(productIds);
 
         return facts;
+    }
+
+    private void extractHardwareFacts(Map<String, String> pinheadFacts, ConduitFacts facts) {
+        String systemUuid = pinheadFacts.get("dmi.system.uuid");
+        if (!isEmpty(systemUuid)) {
+            facts.setBiosUuid(UUID.fromString(systemUuid));
+        }
+
+        String cpuSockets = pinheadFacts.get("cpu.cpu_socket(s)");
+        Integer numCpuSockets = null;
+        if (!isEmpty(cpuSockets)) {
+            numCpuSockets = Integer.parseInt(cpuSockets);
+            facts.setCpuSockets(numCpuSockets);
+        }
+
+        String coresPerSocket = pinheadFacts.get("cpu.core(s)_per_socket");
+        if (!isEmpty(coresPerSocket) && !isEmpty(cpuSockets)) {
+            Integer numCoresPerSocket = Integer.parseInt(coresPerSocket);
+            facts.setCpuCores(numCoresPerSocket * numCpuSockets);
+        }
+
+        String memoryTotal = pinheadFacts.get("memory.memtotal");
+        if (!isEmpty(memoryTotal)) {
+            int memoryBytes = Integer.parseInt(memoryTotal);
+            // memtotal is a little less than accessible memory, round up to next GB
+            int memoryGigabytes = (int) Math.ceil((float) memoryBytes / (float) KIBIBYTES_PER_GIBIBYTE);
+            facts.setMemory(memoryGigabytes);
+        }
+
+        String architecture = pinheadFacts.get("uname.machine");
+        if (!isEmpty(architecture)) {
+            facts.setArchitecture(architecture);
+        }
+    }
+
+    private void extractNetworkFacts(Map<String, String> pinheadFacts, ConduitFacts facts) {
+        String ipAddresses = pinheadFacts.get("Ip-addresses");
+        if (!isEmpty(ipAddresses)) {
+            String[] ipAddressesSplit = ipAddresses.split(", ");
+            facts.setIpAddresses(Arrays.asList(ipAddressesSplit));
+        }
+
+        String fqdn = pinheadFacts.get("network.fqdn");
+        if (!isEmpty(fqdn)) {
+            facts.setFqdn(fqdn);
+        }
+
+        String macAddresses = pinheadFacts.get("Mac-addresses");
+        if (!isEmpty(macAddresses)) {
+            String[] macAddressesSplit = macAddresses.split(", ");
+            facts.setMacAddresses(Arrays.asList(macAddressesSplit));
+        }
+    }
+
+    private void extractHypervisorFacts(Consumer consumer, Map<String, String> pinheadFacts,
+        ConduitFacts facts) {
+
+        String isGuest = pinheadFacts.get("virt.is_guest");
+        if (!isEmpty(isGuest) && !isGuest.equals("Unknown")) {
+            facts.setVirtual(isGuest.equals("True"));
+        }
+
+        String vmHost = consumer.getHypervisorName();
+        if (!isEmpty(vmHost)) {
+            facts.setVmHost(vmHost);
+        }
     }
 
     public void updateInventoryForOrg(String orgId) {

--- a/src/main/java/org/candlepin/insights/pinhead/PinheadService.java
+++ b/src/main/java/org/candlepin/insights/pinhead/PinheadService.java
@@ -57,7 +57,7 @@ public class PinheadService {
         private void fetchPage() {
             try {
                 OrgInventory consumersForOrg = api.getConsumersForOrg(orgId, BATCH_SIZE, nextOffset);
-                consumers = consumersForOrg.getConsumers();
+                consumers = consumersForOrg.getFeeds();
 
                 Status status = consumersForOrg.getStatus();
                 if (status != null && status.getPagination() != null) {
@@ -74,7 +74,7 @@ public class PinheadService {
 
         @Override
         public boolean hasNext() {
-            return !consumers.isEmpty() || nextOffset != null && !nextOffset.equals("");
+            return (consumers != null && !consumers.isEmpty()) || nextOffset != null && !nextOffset.isEmpty();
         }
 
         @Override

--- a/src/test/java/org/candlepin/insights/controller/InventoryControllerTest.java
+++ b/src/test/java/org/candlepin/insights/controller/InventoryControllerTest.java
@@ -74,8 +74,8 @@ public class InventoryControllerTest {
         consumer.setHypervisorName("hypervisor1.test.com");
         consumer.getFacts().put("network.fqdn", "host1.test.com");
         consumer.getFacts().put("dmi.system.uuid", systemUuid);
-        consumer.getFacts().put("ip-addresses", "192.168.1.1, 10.0.0.1");
-        consumer.getFacts().put("mac-addresses", "00:00:00:00:00:00, ff:ff:ff:ff:ff:ff");
+        consumer.getFacts().put("Ip-addresses", "192.168.1.1, 10.0.0.1");
+        consumer.getFacts().put("Mac-addresses", "00:00:00:00:00:00, ff:ff:ff:ff:ff:ff");
         consumer.getFacts().put("cpu.cpu_socket(s)", "2");
         consumer.getFacts().put("uname.machine", "x86_64");
         consumer.getFacts().put("virt.is_guest", "True");

--- a/src/test/java/org/candlepin/insights/pinhead/PinheadServiceTest.java
+++ b/src/test/java/org/candlepin/insights/pinhead/PinheadServiceTest.java
@@ -54,8 +54,8 @@ public class PinheadServiceTest {
                 throws ApiException {
                 if (offset == null) {
                     OrgInventory inventory = new OrgInventory();
-                    inventory.getConsumers().add(consumer1);
-                    inventory.getConsumers().add(consumer2);
+                    inventory.getFeeds().add(consumer1);
+                    inventory.getFeeds().add(consumer2);
                     Status status = new Status();
                     Pagination pagination = new Pagination();
                     pagination.setNextOffset("next");
@@ -65,8 +65,8 @@ public class PinheadServiceTest {
                 }
                 else {
                     OrgInventory inventory = new OrgInventory();
-                    inventory.getConsumers().add(consumer3);
-                    inventory.getConsumers().add(consumer4);
+                    inventory.getFeeds().add(consumer3);
+                    inventory.getFeeds().add(consumer4);
                     Status status = new Status();
                     Pagination pagination = new Pagination();
                     pagination.setNextOffset(null);


### PR DESCRIPTION
For convenience of testing, I created `config/application.properties`
(locally, not checked in) with the contents:

```
rhsm-conduit.inventory-service.use-stub=true
rhsm-conduit.pinhead.url=https://${PINHEAD_DEV}/v1
```

replacing `${PINHEAD_DEV}` with the actual dev hostname.

Then, I hit our endpoint with an org, debugged until it worked, working
through a fair number of orgs.