### PR TITLE
Configure inventory client for API key auth

### DIFF
--- a/insights-inventory-client/src/main/java/org/candlepin/insights/inventory/client/HostsApiFactory.java
+++ b/insights-inventory-client/src/main/java/org/candlepin/insights/inventory/client/HostsApiFactory.java
@@ -45,7 +45,7 @@ public class HostsApiFactory implements FactoryBean<HostsApi> {
             log.info("Using stub host inventory client");
             return new StubHostsApi();
         }
-        ApiClient apiClient = new ApiClient();
+        ApiClient apiClient = Configuration.getDefaultApiClient();
         if (serviceProperties.getUrl() != null) {
             log.info("Host inventory service URL: {}", serviceProperties.getUrl());
             apiClient.setBasePath(serviceProperties.getUrl());
@@ -54,6 +54,13 @@ public class HostsApiFactory implements FactoryBean<HostsApi> {
             log.warn("Host inventory service URL not set...");
         }
 
+        // Inventory API requires us to use key based auth.
+        String apiKey = serviceProperties.getApiKey();
+        if (apiKey == null || apiKey.isEmpty()) {
+            throw new IllegalStateException("No api key has been set for the inventory client.");
+        }
+        apiClient.addDefaultHeader("Authorization", String.format("Bearer %s", apiKey));
+
         return new HostsApi(apiClient);
     }
 
@@ -61,4 +68,5 @@ public class HostsApiFactory implements FactoryBean<HostsApi> {
     public Class<?> getObjectType() {
         return HostsApi.class;
     }
+
 }

--- a/insights-inventory-client/src/main/java/org/candlepin/insights/inventory/client/InventoryServiceProperties.java
+++ b/insights-inventory-client/src/main/java/org/candlepin/insights/inventory/client/InventoryServiceProperties.java
@@ -26,6 +26,7 @@ package org.candlepin.insights.inventory.client;
 public class InventoryServiceProperties {
     private boolean useStub;
     private String url;
+    private String apiKey;
 
     public boolean isUseStub() {
         return useStub;
@@ -41,5 +42,13 @@ public class InventoryServiceProperties {
 
     public void setUrl(String url) {
         this.url = url;
+    }
+
+    public String getApiKey() {
+        return apiKey;
+    }
+
+    public void setApiKey(String apiKey) {
+        this.apiKey = apiKey;
     }
 }

--- a/insights-inventory-client/src/test/java/org/candlepin/insights/inventory/client/HostsApiFactoryTest.java
+++ b/insights-inventory-client/src/test/java/org/candlepin/insights/inventory/client/HostsApiFactoryTest.java
@@ -27,17 +27,45 @@ import org.junit.jupiter.api.Test;
 public class HostsApiFactoryTest {
     @Test
     public void testStubClientConfiguration() throws Exception {
-        InventoryServiceProperties config = new InventoryServiceProperties();
-        config.setUseStub(true);
-        HostsApiFactory factory = new HostsApiFactory(config);
+        InventoryServiceProperties props = new InventoryServiceProperties();
+        props.setUseStub(true);
+        HostsApiFactory factory = new HostsApiFactory(props);
         assertEquals(StubHostsApi.class, factory.getObject().getClass());
     }
 
     @Test
     public void testClientGetsUrlFromConfiguration() throws Exception {
-        InventoryServiceProperties config = new InventoryServiceProperties();
-        config.setUrl("http://example.com/foobar");
-        HostsApiFactory factory = new HostsApiFactory(config);
+        InventoryServiceProperties props = new InventoryServiceProperties();
+        props.setApiKey("mysecret");
+        props.setUrl("http://example.com/foobar");
+        HostsApiFactory factory = new HostsApiFactory(props);
         assertEquals("http://example.com/foobar", factory.getObject().getApiClient().getBasePath());
+    }
+
+    @Test
+    public void testNoErrorWhenApiKeyIsSet() throws Exception {
+        InventoryServiceProperties props = new InventoryServiceProperties();
+        props.setApiKey("mysecret");
+
+        HostsApiFactory factory = new HostsApiFactory(props);
+        factory.getObject();
+    }
+
+    @Test
+    public void throwsIllegalStateWhenApiKeyIsNull() throws Exception {
+        testApiToken(null);
+    }
+
+    @Test
+    public void throwsIllegalStateWhenApiKeyIsEmpty() throws Exception {
+        testApiToken("");
+    }
+
+    private void testApiToken(String key) {
+        InventoryServiceProperties props = new InventoryServiceProperties();
+        props.setApiKey(key);
+        HostsApiFactory factory = new HostsApiFactory(props);
+
+        assertThrows(IllegalStateException.class, () -> factory.getObject());
     }
 }

--- a/src/main/java/org/candlepin/insights/inventory/InventoryService.java
+++ b/src/main/java/org/candlepin/insights/inventory/InventoryService.java
@@ -103,15 +103,7 @@ public class InventoryService {
         facts.add(rhsmFacts);
 
         CreateHostIn host = new CreateHostIn();
-        // Magic account number that tells the inventory app to
-        // ignore the auth header account check. When running
-        // against production insights-inventory, the account in
-        // the header must match what is set on the Host.
-        //
-        // In hosted the account will be the orgId.
-        // TODO Properly set the account when we determine how
-        //      auth will work going forward.
-        host.setAccount("0000001");
+        host.setAccount(orgId);
         host.setFqdn(conduitFacts.getFqdn());
         host.setSubscriptionManagerId(conduitFacts.getSubscriptionManagerId());
         host.setBiosUuid(conduitFacts.getBiosUuid());

--- a/src/main/java/org/candlepin/insights/jackson/ObjectMapperContextResolver.java
+++ b/src/main/java/org/candlepin/insights/jackson/ObjectMapperContextResolver.java
@@ -22,6 +22,7 @@ package org.candlepin.insights.jackson;
 
 import org.candlepin.insights.ApplicationProperties;
 
+import com.fasterxml.jackson.annotation.JsonInclude.Include;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.SerializationFeature;
 import com.fasterxml.jackson.databind.util.StdDateFormat;
@@ -45,6 +46,8 @@ public class ObjectMapperContextResolver implements ContextResolver<ObjectMapper
         objectMapper.disable(SerializationFeature.WRITE_DATES_AS_TIMESTAMPS);
         objectMapper.setDateFormat(new StdDateFormat().withColonInTimeZone(true));
         objectMapper.configure(SerializationFeature.INDENT_OUTPUT, applicationProperties.isPrettyPrintJson());
+        objectMapper.setSerializationInclusion(Include.NON_NULL);
+        objectMapper.setSerializationInclusion(Include.NON_EMPTY);
 
         // Tell the mapper to check the classpath for any serialization/deserialization modules
         // such as the Java8 date/time module (JavaTimeModule).

--- a/src/test/java/org/candlepin/insights/controller/OpenApiSpecControllerTest.java
+++ b/src/test/java/org/candlepin/insights/controller/OpenApiSpecControllerTest.java
@@ -25,8 +25,10 @@ import static org.junit.jupiter.api.Assertions.*;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.context.TestPropertySource;
 
 @SpringBootTest
+@TestPropertySource("classpath:/test.properties")
 public class OpenApiSpecControllerTest {
     @Autowired
     OpenApiSpecController controller;

--- a/src/test/java/org/candlepin/insights/inventory/client/ApiClientTest.java
+++ b/src/test/java/org/candlepin/insights/inventory/client/ApiClientTest.java
@@ -30,7 +30,7 @@ import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.test.context.TestPropertySource;
 
 @SpringBootTest
-@TestPropertySource("classpath:/test.properties")
+@TestPropertySource("classpath:/api_client_test.properties")
 public class ApiClientTest {
     @Autowired
     private HostsApi hostsApi;

--- a/src/test/java/org/candlepin/insights/task/TaskFactoryTest.java
+++ b/src/test/java/org/candlepin/insights/task/TaskFactoryTest.java
@@ -27,9 +27,11 @@ import org.candlepin.insights.task.tasks.UpdateOrgInventoryTask;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.context.TestPropertySource;
 
 
 @SpringBootTest
+@TestPropertySource("classpath:/test.properties")
 public class TaskFactoryTest {
 
     @Autowired

--- a/src/test/java/org/candlepin/insights/task/TaskManagerTest.java
+++ b/src/test/java/org/candlepin/insights/task/TaskManagerTest.java
@@ -28,8 +28,10 @@ import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.test.context.TestPropertySource;
 
 @SpringBootTest
+@TestPropertySource("classpath:/test.properties")
 public class TaskManagerTest {
 
     @MockBean

--- a/src/test/java/org/candlepin/insights/task/TaskWorkerTest.java
+++ b/src/test/java/org/candlepin/insights/task/TaskWorkerTest.java
@@ -28,8 +28,10 @@ import org.mockito.Mock;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.test.context.TestPropertySource;
 
 @SpringBootTest
+@TestPropertySource("classpath:/test.properties")
 public class TaskWorkerTest {
 
     @MockBean

--- a/src/test/resources/api_client_test.properties
+++ b/src/test/resources/api_client_test.properties
@@ -1,0 +1,3 @@
+rhsm-conduit.version=TEST
+rhsm-conduit.inventory-service.url=https://localhost/api/hostinventory
+rhsm-conduit.inventory-service.apiKey=mysecret

--- a/src/test/resources/test.properties
+++ b/src/test/resources/test.properties
@@ -1,4 +1,4 @@
 # Drop properties we want to load in a test here
 
 rhsm-conduit.version=TEST
-rhsm-conduit.inventory-service.url=https://localhost/api/hostinventory
+rhsm-conduit.inventory-service.useStub=true


### PR DESCRIPTION
This patch configures the inventory client to use an auth key when sending hosts to inventory. It also addresses the validation checks that were recently added to the inventory service.

Testing
======
1. Deploy a local insights-inventory instance:
```
# Create a new database user/database
su - postgres
createuser --pwprompt -d insights
createdb -U insights inventory 

# Set up insights
git clone git@github.com:RedHatInsights/insights-inventory.git

# From the checkout dir
export INVENTORY_DB_NAME=inventory
pipenv install --dev
pipenv shell
python manage.py db upgrade

# Run the inventory application
LISTEN_PORT=8881 INVENTORY_LOGGING_CONFIG_FILE=logconfig.ini prometheus_multiproc_dir=./prometheumultiprocess/ FLASK_DEBUG=1 INVENTORY_DB_NAME="inventory" INVENTORY_SHARED_SECRET=mysecret python run.py
```

2. Deploy rhsm-insights from this branch
```
./gradlew clean assemble && java -jar -Drhsm-conduit.inventory-service.url=http://localhost:8881/r/insights/platform/inventory/api/v1 -Drhsm-conduit.pinhead.useStub=true  -Drhsm-conduit.inventory-service.api-key=mysecret build/libs/rhsm-conduit-1.0.0.jar
```

3. Send some dummy data to the inventory. Ensure there are no errors when sending.
```
curl -X POST http://localhost:8080/rhsm-conduit/v1/inventories/0000001
```

4. Check the inventory to make sure that the data was added:
```
curl -H "x-rh-identity: eyJpZGVudGl0eSI6eyJhY2NvdW50X251bWJlciI6IjAwMDAwMDEifX0=" -i http://localhost:8881/r/insights/platform/inventory/api/v1/hosts
```
**NOTE** We have to fake the x-rh-identity header when retrieving inventory data from the inventory service via curl. The value is base64 encoded JSON that contains the account number that we are fetching data for. The header in step 4 contains the account number 0000001.

If you want to try sending host data for another account, you'd need to do the following:
```
# Send some hosts to inventory for org: mstead-test-org
curl -X POST http://localhost:8080/rhsm-conduit/v1/inventories/mstead-test-org

# Forge the header
$ echo '{"identity":{"account_number":"mstead-test-org"}}' | base64
eyJpZGVudGl0eSI6eyJhY2NvdW50X251bWJlciI6Im1zdGVhZC10ZXN0LW9yZyJ9fQo=

# Make the request to inventory with the forged header
curl -H "x-rh-identity: eyJpZGVudGl0eSI6eyJhY2NvdW50X251bWJlciI6Im1zdGVhZC10ZXN0LW9yZyJ9fQo=" -i http://localhost:8881/r/insights/platform/inventory/api/v1/hosts
