### PR TITLE
Updated quartz DB service name

### DIFF
--- a/openshift/template_rhsm-conduit.yaml
+++ b/openshift/template_rhsm-conduit.yaml
@@ -251,7 +251,7 @@ objects:
       template.openshift.io/expose-uri: postgres://{.spec.clusterIP}:{.spec.ports[?(.name=="postgresql")].port}
     labels:
       app: ${APPLICATION_NAME}
-    name: quartz-postgresql
+    name: ${APPLICATION_NAME}-quartz-postgresql
   spec:
     ports:
     - name: postgresql


### PR DESCRIPTION
Currently when deploying rhsm-conduit with a different app name
from the template, it complains that the quartz-db service already exists.

This spins up the service with a name corresponding to the app name that
was specified.