### PR TITLE
Ignore unknown properties when deserializing JSON from clients

### DIFF
--- a/src/main/java/org/candlepin/insights/jackson/ObjectMapperContextResolver.java
+++ b/src/main/java/org/candlepin/insights/jackson/ObjectMapperContextResolver.java
@@ -23,6 +23,7 @@ package org.candlepin.insights.jackson;
 import org.candlepin.insights.ApplicationProperties;
 
 import com.fasterxml.jackson.annotation.JsonInclude.Include;
+import com.fasterxml.jackson.databind.DeserializationFeature;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.SerializationFeature;
 import com.fasterxml.jackson.databind.util.StdDateFormat;
@@ -48,6 +49,7 @@ public class ObjectMapperContextResolver implements ContextResolver<ObjectMapper
         objectMapper.configure(SerializationFeature.INDENT_OUTPUT, applicationProperties.isPrettyPrintJson());
         objectMapper.setSerializationInclusion(Include.NON_NULL);
         objectMapper.setSerializationInclusion(Include.NON_EMPTY);
+        objectMapper.disable(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES);
 
         // Tell the mapper to check the classpath for any serialization/deserialization modules
         // such as the Java8 date/time module (JavaTimeModule).

--- a/src/test/java/org/candlepin/insights/jackson/ObjectMapperContextResolverTest.java
+++ b/src/test/java/org/candlepin/insights/jackson/ObjectMapperContextResolverTest.java
@@ -22,6 +22,7 @@ package org.candlepin.insights.jackson;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import org.candlepin.insights.ApplicationProperties;
@@ -98,6 +99,24 @@ public class ObjectMapperContextResolverTest {
         assertContainsProperty(data, "value2", v2);
     }
 
+    @Test
+    public void testDeserialization() throws Exception {
+        String pojoJson = "{\"value1\":\"value1\",\"value2\":\"value2\"}";
+        TestPojo pojo = mapper.readValue(pojoJson, TestPojo.class);
+        assertNotNull(pojo);
+        assertEquals("value1", pojo.getValue1());
+        assertEquals("value2", pojo.getValue2());
+    }
+
+    @Test
+    public void testDeserializationDoesNotFailOnUnknownProperties() throws Exception {
+        String pojoJson = "{\"value1\":\"value1\",\"value2\":\"value2\",\"value3\":\"value3\"}";
+        TestPojo pojo = mapper.readValue(pojoJson, TestPojo.class);
+        assertNotNull(pojo);
+        assertEquals("value1", pojo.getValue1());
+        assertEquals("value2", pojo.getValue2());
+    }
+
     private void assertContainsProperty(String data, String key, String value)  throws Exception {
         String toFind = String.format("\"%s\":\"%s\"", key, value);
         assertTrue(data.contains(toFind));
@@ -107,31 +126,4 @@ public class ObjectMapperContextResolverTest {
         assertFalse(data.contains(property));
     }
 
-    private class TestPojo {
-        private String value1;
-        private String value2;
-
-        public TestPojo() { }
-
-        public TestPojo(String value1, String value2) {
-            this.value1 = value1;
-            this.value2 = value2;
-        }
-
-        public String getValue1() {
-            return value1;
-        }
-
-        public void setValue1(String value1) {
-            this.value1 = value1;
-        }
-
-        public String getValue2() {
-            return value2;
-        }
-
-        public void setValue2(String value2) {
-            this.value2 = value2;
-        }
-    }
 }

--- a/src/test/java/org/candlepin/insights/jackson/TestPojo.java
+++ b/src/test/java/org/candlepin/insights/jackson/TestPojo.java
@@ -1,0 +1,49 @@
+/*
+ * Copyright (c) 2009 - 2019 Red Hat, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ *
+ * Red Hat trademarks are not licensed under GPLv3. No permission is
+ * granted to use or replicate Red Hat trademarks that are incorporated
+ * in this software or its documentation.
+ */
+package org.candlepin.insights.jackson;
+
+public class TestPojo {
+    private String value1;
+    private String value2;
+
+    public TestPojo() { }
+
+    public TestPojo(String value1, String value2) {
+        this.value1 = value1;
+        this.value2 = value2;
+    }
+
+    public String getValue1() {
+        return value1;
+    }
+
+    public void setValue1(String value1) {
+        this.value1 = value1;
+    }
+
+    public String getValue2() {
+        return value2;
+    }
+
+    public void setValue2(String value2) {
+        this.value2 = value2;
+    }
+}


### PR DESCRIPTION
We will use the defined/generated POJOs to describe what properties we do/do not
care about when fetching data from pinhead. This avoids the constant errors we are
getting when the pinhead API changes.