### PR TITLE
Fixed NPE when UUIDs are null from Pinhead

### DIFF
--- a/src/main/java/org/candlepin/insights/controller/InventoryController.java
+++ b/src/main/java/org/candlepin/insights/controller/InventoryController.java
@@ -36,7 +36,6 @@ import java.util.LinkedList;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
-import java.util.UUID;
 import java.util.stream.Collectors;
 
 import javax.validation.ConstraintViolation;
@@ -78,7 +77,7 @@ public class InventoryController {
         final Map<String, String> pinheadFacts = consumer.getFacts();
         ConduitFacts facts = new ConduitFacts();
 
-        facts.setSubscriptionManagerId(UUID.fromString(consumer.getUuid()));
+        facts.setSubscriptionManagerId(consumer.getUuid());
 
         extractNetworkFacts(pinheadFacts, facts);
         extractHardwareFacts(pinheadFacts, facts);
@@ -94,7 +93,7 @@ public class InventoryController {
     private void extractHardwareFacts(Map<String, String> pinheadFacts, ConduitFacts facts) {
         String systemUuid = pinheadFacts.get(DMI_SYSTEM_UUID);
         if (!isEmpty(systemUuid)) {
-            facts.setBiosUuid(UUID.fromString(systemUuid));
+            facts.setBiosUuid(systemUuid);
         }
 
         String cpuSockets = pinheadFacts.get(CPU_SOCKETS);

--- a/src/main/java/org/candlepin/insights/inventory/ConduitFacts.java
+++ b/src/main/java/org/candlepin/insights/inventory/ConduitFacts.java
@@ -23,7 +23,6 @@ package org.candlepin.insights.inventory;
 import org.hibernate.validator.constraints.Length;
 
 import java.util.List;
-import java.util.UUID;
 
 import javax.validation.constraints.Pattern;
 import javax.validation.constraints.Positive;
@@ -32,8 +31,8 @@ import javax.validation.constraints.Positive;
  * POJO that holds all facts scoped for collection by the conduit.
  */
 public class ConduitFacts {
-    private UUID subscriptionManagerId;
-    private UUID biosUuid;
+    private String subscriptionManagerId;
+    private String biosUuid;
 
     // This is a soft validation.  Bogus IP addresses like "999.999.999.999" will still validate
     private List<@Pattern(regexp = "^\\d{1,3}\\.\\d{1,3}\\.\\d{1,3}\\.\\d{1,3}$") String> ipAddresses;
@@ -59,19 +58,19 @@ public class ConduitFacts {
     private String vmHost;
     private List<String> rhProd;
 
-    public UUID getSubscriptionManagerId() {
+    public String getSubscriptionManagerId() {
         return subscriptionManagerId;
     }
 
-    public void setSubscriptionManagerId(UUID subscriptionManagerId) {
+    public void setSubscriptionManagerId(String subscriptionManagerId) {
         this.subscriptionManagerId = subscriptionManagerId;
     }
 
-    public UUID getBiosUuid() {
+    public String getBiosUuid() {
         return biosUuid;
     }
 
-    public void setBiosUuid(UUID biosUuid) {
+    public void setBiosUuid(String biosUuid) {
         this.biosUuid = biosUuid;
     }
 

--- a/src/main/java/org/candlepin/insights/inventory/InventoryService.java
+++ b/src/main/java/org/candlepin/insights/inventory/InventoryService.java
@@ -105,8 +105,8 @@ public class InventoryService {
         CreateHostIn host = new CreateHostIn();
         host.setAccount(orgId);
         host.setFqdn(conduitFacts.getFqdn());
-        host.setSubscriptionManagerId(conduitFacts.getSubscriptionManagerId().toString());
-        host.setBiosUuid(conduitFacts.getBiosUuid().toString());
+        host.setSubscriptionManagerId(conduitFacts.getSubscriptionManagerId());
+        host.setBiosUuid(conduitFacts.getBiosUuid());
         host.setIpAddresses(conduitFacts.getIpAddresses());
         host.setMacAddresses(conduitFacts.getMacAddresses());
         host.facts(facts);


### PR DESCRIPTION
Removed use of UUID altogether since we were converting from String
to UUID when coming from Pinhead, and then back to String again when
sending to inventory.