### PR TITLE
Update README regarding build with Java8

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,8 @@
-Run using
+## Build and Run rhsm-conduit
+
+In order to build rhsm-conduit, make sure you have Java SDK 8 installed (Java 1.8.x).
+
+Build and run using the following line:
 
 ```
 ./gradlew build && java -jar build/libs/rhsm-conduit-1.0.0.jar


### PR DESCRIPTION
Add a few lines about building rhsm-conduit requires to use Java SDK 8 (1.8.x), since building with Java11 will not work.