### PR TITLE
Used Spring Kafka to implement a Kafka TaskQueue implementation.

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -28,6 +28,7 @@ ext {
     slf4j_version = "1.7.25"
     mockito_version = "2.23.4"
     guava_version="19.0"
+    spring_kafka_version = "2.2.4.RELEASE"
 }
 
 allprojects {
@@ -97,6 +98,7 @@ dependencies {
     compile "net.logstash.logback:logstash-logback-encoder:5.3"
     compile "io.micrometer:micrometer-registry-prometheus:1.1.2"
     compile "org.webjars:swagger-ui:3.20.8"
+    compile "org.springframework.kafka:spring-kafka:$spring_kafka_version"
     compile("org.quartz-scheduler:quartz:2.3.0") {
         // These excludes are present in the spring-boot-starter-quartz POM file but we don't want to use
         // the starter since it pulls in some other items
@@ -104,6 +106,9 @@ dependencies {
         exclude group: "com.zaxxer", module: "HikariCP-java6"
     }
     compile "com.google.guava:guava:$guava_version"
+
+    // Test dependencies
+    testCompile("org.springframework.kafka:spring-kafka-test:${spring_kafka_version}")
 
     // Runtime deps that will be included in the result package but not on the compile classpath.  I.e.
     // implementations of APIs we are using.

--- a/src/main/java/org/candlepin/insights/task/TaskDescriptor.java
+++ b/src/main/java/org/candlepin/insights/task/TaskDescriptor.java
@@ -144,6 +144,11 @@ public class TaskDescriptor {
             return this;
         }
 
+        public TaskDescriptorBuilder setArgs(Map<String, String> args) {
+            this.args = new HashMap<>(args);
+            return this;
+        }
+
         public TaskDescriptor build() {
             return new TaskDescriptor(this);
         }

--- a/src/main/java/org/candlepin/insights/task/queue/kafka/KafkaTaskProcessor.java
+++ b/src/main/java/org/candlepin/insights/task/queue/kafka/KafkaTaskProcessor.java
@@ -1,0 +1,59 @@
+/*
+ * Copyright (c) 2009 - 2019 Red Hat, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ *
+ * Red Hat trademarks are not licensed under GPLv3. No permission is
+ * granted to use or replicate Red Hat trademarks that are incorporated
+ * in this software or its documentation.
+ */
+package org.candlepin.insights.task.queue.kafka;
+
+
+import org.candlepin.insights.task.TaskExecutionException;
+import org.candlepin.insights.task.TaskFactory;
+import org.candlepin.insights.task.TaskQueueConfiguration;
+import org.candlepin.insights.task.TaskWorker;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.kafka.annotation.KafkaListener;
+
+
+/**
+ * Responsible for receiving task messages from Kafka when they become available.
+ */
+public class KafkaTaskProcessor {
+    private static final Logger log = LoggerFactory.getLogger(KafkaTaskProcessor.class);
+
+    private TaskWorker worker;
+
+    public KafkaTaskProcessor(TaskFactory taskFactory) {
+        worker = new TaskWorker(taskFactory);
+    }
+
+    @KafkaListener(id = "rhsm-conduit-task-processor", topics = TaskQueueConfiguration.TASK_GROUP)
+    public void onTaskAvailable(TaskMessage taskMessage) {
+        try {
+            log.info("Message received from kafka: {}", taskMessage);
+            worker.executeTask(taskMessage.toDescriptor());
+        }
+        catch (TaskExecutionException e) {
+            // If a task fails to execute for any reason, it is logged and will
+            // not get retried.
+            log.error("Failed to execute task: {}", taskMessage, e);
+        }
+    }
+
+}

--- a/src/main/java/org/candlepin/insights/task/queue/kafka/KafkaTaskQueue.java
+++ b/src/main/java/org/candlepin/insights/task/queue/kafka/KafkaTaskQueue.java
@@ -1,0 +1,53 @@
+/*
+ * Copyright (c) 2009 - 2019 Red Hat, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ *
+ * Red Hat trademarks are not licensed under GPLv3. No permission is
+ * granted to use or replicate Red Hat trademarks that are incorporated
+ * in this software or its documentation.
+ */
+package org.candlepin.insights.task.queue.kafka;
+
+import org.candlepin.insights.task.TaskDescriptor;
+import org.candlepin.insights.task.queue.TaskQueue;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.kafka.core.KafkaTemplate;
+
+/**
+ * A task queue implementation that is backed by a kafka. Messages are sent to kafka
+ * when queued. The topic that a task is published on is defined by TaskDescriptor.groupId.
+ */
+public class KafkaTaskQueue implements TaskQueue {
+
+    private static final Logger log = LoggerFactory.getLogger(KafkaTaskQueue.class);
+
+    @Autowired
+    private KafkaTemplate<String, TaskMessage> producer;
+
+    public KafkaTaskQueue() {
+        log.info("Creating Kafka task queue...");
+    }
+
+    @Override
+    public void enqueue(TaskDescriptor taskDescriptor) {
+        log.info("Queuing task: {}", taskDescriptor);
+        // Message key is auto-generated.
+        producer.send(taskDescriptor.getGroupId(), null, new TaskMessage(taskDescriptor));
+    }
+
+}

--- a/src/main/java/org/candlepin/insights/task/queue/kafka/KafkaTaskQueueConfiguration.java
+++ b/src/main/java/org/candlepin/insights/task/queue/kafka/KafkaTaskQueueConfiguration.java
@@ -1,0 +1,138 @@
+/*
+ * Copyright (c) 2009 - 2019 Red Hat, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ *
+ * Red Hat trademarks are not licensed under GPLv3. No permission is
+ * granted to use or replicate Red Hat trademarks that are incorporated
+ * in this software or its documentation.
+ */
+package org.candlepin.insights.task.queue.kafka;
+
+import org.candlepin.insights.task.TaskFactory;
+import org.candlepin.insights.task.queue.TaskQueue;
+
+import org.apache.kafka.clients.consumer.ConsumerConfig;
+import org.apache.kafka.clients.producer.ProducerConfig;
+import org.apache.kafka.common.serialization.StringDeserializer;
+import org.apache.kafka.common.serialization.StringSerializer;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
+import org.springframework.boot.autoconfigure.kafka.KafkaProperties;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.context.annotation.PropertySource;
+import org.springframework.kafka.annotation.EnableKafka;
+import org.springframework.kafka.config.ConcurrentKafkaListenerContainerFactory;
+import org.springframework.kafka.config.KafkaListenerContainerFactory;
+import org.springframework.kafka.core.ConsumerFactory;
+import org.springframework.kafka.core.DefaultKafkaConsumerFactory;
+import org.springframework.kafka.core.DefaultKafkaProducerFactory;
+import org.springframework.kafka.core.KafkaTemplate;
+import org.springframework.kafka.core.ProducerFactory;
+import org.springframework.kafka.listener.ConcurrentMessageListenerContainer;
+import org.springframework.kafka.support.serializer.ErrorHandlingDeserializer2;
+import org.springframework.kafka.support.serializer.JsonDeserializer;
+import org.springframework.kafka.support.serializer.JsonSerializer;
+
+import java.util.Map;
+
+
+/**
+ * A spring configuration that configures the required Beans to set up a KafkaTaskQueue.
+ *
+ * To enable this queue, set the following in the rhsm-conduit.properties file:
+ * <pre>
+ *     rhsm-conduit.tasks.queue=kafka
+ * </pre>
+ */
+@EnableKafka
+@Configuration
+@PropertySource("classpath:/rhsm-conduit.properties")
+public class KafkaTaskQueueConfiguration {
+
+    private static final String  TYPE_MAPPINGS = "task-message:" + TaskMessage.class.getCanonicalName();
+
+    @Autowired
+    private KafkaProperties kafkaProperties;
+
+    @Bean
+    @ConditionalOnProperty(prefix = "rhsm-conduit.tasks", name = "queue", havingValue = "kafka")
+    public ProducerFactory<String, TaskMessage> producerFactory() {
+        return new DefaultKafkaProducerFactory<>(producerConfig());
+    }
+
+    @Bean
+    @ConditionalOnProperty(prefix = "rhsm-conduit.tasks", name = "queue", havingValue = "kafka")
+    public Map<String, Object> producerConfig() {
+        Map<String, Object> config = kafkaProperties.buildProducerProperties();
+        config.put(ProducerConfig.KEY_SERIALIZER_CLASS_CONFIG, StringSerializer.class);
+        config.put(ProducerConfig.VALUE_SERIALIZER_CLASS_CONFIG, JsonSerializer.class);
+        config.put(JsonSerializer.TYPE_MAPPINGS, TYPE_MAPPINGS);
+        return config;
+    }
+
+    @Bean
+    @ConditionalOnProperty(prefix = "rhsm-conduit.tasks", name = "queue", havingValue = "kafka")
+    public KafkaTemplate<String, TaskMessage> kafkaProducerTemplate() {
+        return new KafkaTemplate<String, TaskMessage>(producerFactory());
+    }
+
+    @Bean
+    @ConditionalOnProperty(prefix = "rhsm-conduit.tasks", name = "queue", havingValue = "kafka")
+    KafkaListenerContainerFactory<ConcurrentMessageListenerContainer<String, TaskMessage>>
+        kafkaListenerContainerFactory() {
+        ConcurrentKafkaListenerContainerFactory<String, TaskMessage> factory =
+            new ConcurrentKafkaListenerContainerFactory<>();
+        factory.setConsumerFactory(consumerFactory());
+        // Concurrency should be set to the number of partitions for the target topic.
+        factory.setConcurrency(kafkaProperties.getListener().getConcurrency());
+        return factory;
+    }
+
+    @Bean
+    @ConditionalOnProperty(prefix = "rhsm-conduit.tasks", name = "queue", havingValue = "kafka")
+    public ConsumerFactory<String, TaskMessage> consumerFactory() {
+        return new DefaultKafkaConsumerFactory<>(consumerConfigs());
+    }
+
+    @Bean
+    @ConditionalOnProperty(prefix = "rhsm-conduit.tasks", name = "queue", havingValue = "kafka")
+    public Map<String, Object> consumerConfigs() {
+        Map<String, Object> props = kafkaProperties.buildConsumerProperties();
+
+        props.put(ConsumerConfig.KEY_DESERIALIZER_CLASS_CONFIG, StringDeserializer.class);
+        // Prevent the client from continuously replaying a message that fails to deserialize.
+        props.put(ConsumerConfig.VALUE_DESERIALIZER_CLASS_CONFIG, ErrorHandlingDeserializer2.class);
+        props.put(ErrorHandlingDeserializer2.VALUE_DESERIALIZER_CLASS, JsonDeserializer.class);
+        props.put(JsonDeserializer.TRUSTED_PACKAGES, KafkaTaskQueue.class.getPackage().getName());
+        props.put(JsonDeserializer.TYPE_MAPPINGS, TYPE_MAPPINGS);
+
+        return props;
+    }
+
+
+    @Bean
+    @ConditionalOnProperty(prefix = "rhsm-conduit.tasks", name = "queue", havingValue = "kafka")
+    public TaskQueue kafkaTaskQueue() {
+        return new KafkaTaskQueue();
+    }
+
+    @Bean
+    @ConditionalOnProperty(prefix = "rhsm-conduit.tasks", name = "queue", havingValue = "kafka")
+    public KafkaTaskProcessor taskProcessor(TaskFactory taskFactory) {
+        return new KafkaTaskProcessor(taskFactory);
+    }
+
+}

--- a/src/main/java/org/candlepin/insights/task/queue/kafka/TaskMessage.java
+++ b/src/main/java/org/candlepin/insights/task/queue/kafka/TaskMessage.java
@@ -1,0 +1,87 @@
+/*
+ * Copyright (c) 2009 - 2019 Red Hat, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ *
+ * Red Hat trademarks are not licensed under GPLv3. No permission is
+ * granted to use or replicate Red Hat trademarks that are incorporated
+ * in this software or its documentation.
+ */
+package org.candlepin.insights.task.queue.kafka;
+
+import org.candlepin.insights.task.TaskDescriptor;
+import org.candlepin.insights.task.TaskType;
+
+import java.util.HashMap;
+import java.util.Map;
+
+/**
+ * Represents the task data that is stored in Kafka. This is pretty much a mirror
+ * of TaskDescriptor but serves as the DTO for sending through Kafka.
+ */
+public class TaskMessage {
+
+    private String groupId;
+    private TaskType type;
+    private Map<String, String> args;
+
+    public TaskMessage() {
+    }
+
+    public TaskMessage(TaskDescriptor descriptor) {
+        groupId = descriptor.getGroupId();
+        type = descriptor.getTaskType();
+        args = new HashMap<>(descriptor.getTaskArgs());
+    }
+
+    public String getGroupId() {
+        return groupId;
+    }
+
+    public void setGroupId(String groupId) {
+        this.groupId = groupId;
+    }
+
+    public TaskType getType() {
+        return type;
+    }
+
+    public void setType(TaskType type) {
+        this.type = type;
+    }
+
+    public Map<String, String> getArgs() {
+        return args;
+    }
+
+    public void setArgs(Map<String, String> args) {
+        this.args = args;
+    }
+
+    public TaskDescriptor toDescriptor() {
+        return TaskDescriptor.builder(this.type, this.groupId).setArgs(this.args).build();
+    }
+
+    @Override
+    public String toString() {
+        StringBuilder output = new StringBuilder();
+        output.append(String.format("%s[ ", TaskMessage.class.getSimpleName()));
+        output.append(String.format("Group ID: %s, ", groupId));
+        output.append(String.format("Type: %s, ", type));
+        output.append("Args: [");
+        args.entrySet().forEach((e) -> output.append(String.format("%s: %s ", e.getKey(), e.getValue())));
+        output.append("]]");
+        return output.toString();
+    }
+}

--- a/src/main/resources/rhsm-conduit.properties
+++ b/src/main/resources/rhsm-conduit.properties
@@ -4,11 +4,27 @@
 server.servlet.context-path=${PATH_PREFIX:}
 rhsm-conduit.prettyPrintJson=false
 rhsm-conduit.package_uri_mappings.org.candlepin.insights=${APP_NAME:rhsm-conduit}/v1
+
+# Scheduled inventory updates
 rhsm-conduit.org-sync.schedule=0 */2 * * * ?
 rhsm-conduit.org-sync.strategy = fileBasedOrgListStrategy
+
 # Use Spring Resource notation for this (e.g. "classpath:" or "file:")
 rhsm-conduit.org-sync.fileBasedOrgListStrategy.org-resource-location=classpath:empty-org-list.txt
 
-# Default datasource.  Override by pulling in another rhsm-conduit.properties file via an
+# Default Quartz datasource.  Override by pulling in another rhsm-conduit.properties file via an
 # -Dspring.config.additional-location argument
 rhsm-conduit.datasource.platform=hsqldb
+
+# General kafka configuration
+#rhsm-conduit.tasks.queue=kafka
+
+# The number of threads that will be processing messages (should match
+# the number of partitions on the queue)
+#spring.kafka.listener.concurrency=1
+#spring.kafka.bootstrap-servers=localhost:9092
+#spring.kafka.consumer.properties.reconnect.backoff.ms=2000
+#spring.kafka.consumer.properties.reconnect.backoff.max.ms=10000
+#spring.kafka.consumer.properties.default.api.timeout.ms=480000
+
+

--- a/src/test/java/org/candlepin/insights/task/queue/kafka/KafkaTaskQueueTest.java
+++ b/src/test/java/org/candlepin/insights/task/queue/kafka/KafkaTaskQueueTest.java
@@ -1,0 +1,104 @@
+/*
+ * Copyright (c) 2009 - 2019 Red Hat, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ *
+ * Red Hat trademarks are not licensed under GPLv3. No permission is
+ * granted to use or replicate Red Hat trademarks that are incorporated
+ * in this software or its documentation.
+ */
+package org.candlepin.insights.task.queue.kafka;
+
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.when;
+
+import org.candlepin.insights.task.Task;
+import org.candlepin.insights.task.TaskDescriptor;
+import org.candlepin.insights.task.TaskFactory;
+import org.candlepin.insights.task.TaskManager;
+import org.candlepin.insights.task.TaskQueueConfiguration;
+import org.candlepin.insights.task.TaskType;
+
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.kafka.test.context.EmbeddedKafka;
+import org.springframework.test.annotation.DirtiesContext;
+import org.springframework.test.context.TestPropertySource;
+
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.TimeUnit;
+
+
+@SpringBootTest
+@TestPropertySource("classpath:/kafka_test.properties")
+@DirtiesContext
+@EmbeddedKafka(partitions = 1, topics = {TaskQueueConfiguration.TASK_GROUP})
+public class KafkaTaskQueueTest {
+
+    @MockBean
+    private TaskFactory factory;
+
+    @Autowired
+    private TaskManager manager;
+
+    @Test
+    public void testSendAndReceiveTaskMessage() throws InterruptedException {
+        String orgId = "test_org";
+        TaskDescriptor taskDescriptor = TaskDescriptor.builder(
+            TaskType.UPDATE_ORG_INVENTORY, TaskQueueConfiguration.TASK_GROUP)
+            .setArg("org_id", orgId)
+            .build();
+
+        // Expect the task to be ran once.
+        CountDownLatch latch = new CountDownLatch(1);
+        CountDownTask cdt = new CountDownTask(latch);
+
+        when(factory.build(eq(taskDescriptor))).thenReturn(cdt);
+
+        manager.updateOrgInventory(orgId);
+
+        // Wait a max of 5 seconds for the task to be executed
+        latch.await(5L, TimeUnit.SECONDS);
+        assertTrue(cdt.taskWasExecuted(), "The task failed to execute. The message was not received.");
+    }
+
+    /**
+     * A testing Task that uses a latch to allow the calling test to know that it has been executed.
+     * It provides an executed field to allow tests to verify that the Task has actually been run
+     * in cases where latch.await(timeout) times out waiting for it to execute.
+     */
+    private class CountDownTask implements Task {
+
+        private CountDownLatch latch;
+        private boolean executed;
+
+        public CountDownTask(CountDownLatch latch) {
+            this.latch = latch;
+        }
+
+        @Override
+        public void execute() {
+            executed = true;
+            latch.countDown();
+        }
+
+        public boolean taskWasExecuted() {
+            return executed;
+        }
+    }
+
+}

--- a/src/test/resources/kafka_test.properties
+++ b/src/test/resources/kafka_test.properties
@@ -1,0 +1,14 @@
+# A configuration file to be used when testing kafka integration.
+
+rhsm-conduit.version=TEST
+
+# Stub out the inventory and pinhead services
+rhsm-conduit.inventory-service.useStub=true
+rhsm-conduit.pinhead.useStub=true
+
+# Configure the kafka task queue and the embedded kafka broker
+rhsm-conduit.tasks.queue=kafka
+spring.kafka.bootstrap-servers=${spring.embedded.kafka.brokers}
+# In tests, messages may be sent before the listener has been assigned the topic
+# so we ensure that when the listener comes online it starts from first message.
+spring.kafka.consumer.auto-offset-reset=earliest


### PR DESCRIPTION
Used Spring Kafka to implement a Kafka TaskQueue implementation.

When the TaskManager queues a task, a message is sent to Kafka
via the rhsm-conduit-tasks topic.

A KafkaListener is configured to listen to the rhsm-conduit-tasks topic
and is notified when a message is available. The message is then translated
to a Task and is run via the TaskWorker.

If Task execution fails, the error is logged and the message is considered
processed.

To enable this queue, the following property must be set as an env var
or in the rhsm-conduit.properties config file:
    rhsm-conduit.tasks.queue=kafka


Spring Kafka's auto-configure is used to configure the producer/consumer. Any of the
confurations defined by Spring Kafka are defines with the "spring.kafka" prefix as
per the documentation. Customizing the consumer or producer via properties not included
with auto-configure can be specified via:
   spring.kafka.consunmer.properties.MY_CONSUMER_PROPERTY
   spring.kafka.producer.properties.MY_PRODUCER_PROPERTY


To increase the number of messages that can be processed concurrently, the
topic must be configured with a number of partitions equal to the value of the
spring.kafka.listener.concurrency property.

## Testing

1. Deploy kafka wiht docker:
```bash
docker run --rm --net host landoop/fast-data-dev
```

Web console can be found here: 
http://localhost:3030

2. Download and untar the Kafka tooling.
```bash
http://apache.mirror.iweb.ca/kafka/2.2.0/kafka_2.12-2.2.0.tgz
```
3. The required topic that rhsm-conduit will use will be created according to the auto-create settings on the broker, if it does not already exist. However, we will use the client tooling in this example. Here we create a new 'rhsm-conduit-tasks' topic with a single partition and a replication-factor of 1 since we have only one kafka broker.
```bash
./kafka-topics.sh --create --zookeeper localhost:2181 --replication-factor 1 --partitions 1 --topic rhsm-conduit-tasks
```

4. Configure rhsm-conduit to use Kafka. uncomment the queue config and the kafka specific properties.
```
# General kafka configuration
rhsm-conduit.tasks.queue=kafka

# The number of threads that will be processing messages (should match
# the number of partitions on the queue)
spring.kafka.listener.concurrency=1
spring.kafka.bootstrap-servers=localhost:9092
spring.kafka.consumer.properties.reconnect.backoff.ms=2000
spring.kafka.consumer.properties.reconnect.backoff.max.ms=10000
spring.kafka.consumer.properties.default.api.timeout.ms=480000
```
5. Deploy rhsm-conduit and verify in the logs that the kafka task queue is being used.
6. Manually trigger a few updates so that you can see them queuing up. Note that in this configuration task messages will be consumed 1 at a time.
```bash
for i in {1..10}; do curl -X POST http://localhost:8080/rhsm-conduit/v1/inventories/2144245 ; done
```

7. Stop the server and increase the number of partitions for the task topic.
```
./kafka-topics.sh --alter --zookeeper localhost:2181 --topic rhsm-conduit-tasks  --partitions 10
```

8. Increase the number of threads that will process task messages in rhsm-conduit, and restart the service:
```
# The number of threads that will be processing messages (should match
# the number of partitions on the queue)
spring.kafka.listener.concurrency=10
```

9. Trigger a few concurrent updates and take note that there are no more than 10 running at the same time.
```bash
for i in {1..20}; do curl -X POST http://localhost:8080/rhsm-conduit/v1/inventories/2144245 ; done
```