### PR TITLE
Remove double substitution from liveness/readiness probes.

### DIFF
--- a/openshift/example_config/rhsm-conduit.properties
+++ b/openshift/example_config/rhsm-conduit.properties
@@ -1,6 +1,3 @@
-# override default for PATH_PREFIX
-server.servlet.context-path=${PATH_PREFIX:/r/insights/platform}
-
 # inventory service options
 rhsm-conduit.inventory-service.url=localhost
 rhsm-conduit.inventory-service.apiKey=mysecret

--- a/openshift/template_rhsm-conduit.yaml
+++ b/openshift/template_rhsm-conduit.yaml
@@ -50,13 +50,8 @@ objects:
               command:
                 - /usr/bin/curl
                 - '-s'
-                # The ${${X:=blah}:+$X/} construct sets X to blah if X is unset or null and then outputs X
-                # with a trailing slash.  The purpose is to avoid requiring a trailing slash when PATH_PREFIX
-                # is set (required if using a construct like ${PATH_PREFIX:-blah/}${APP_NAME} while also
-                # preventing a superfluous slash if PATH_PREFIX is empty which occurs in the less complex
-                # ${PATH_PREFIX:-blah}/${APP_NAME} construction
-                - 'http://localhost:8080/${${PATH_PREFIX:=/r/insights/platform}:+$PATH_PREFIX/}${APP_NAME:-rhsm-conduit}/v1/status'
-            initialDelaySeconds: 90
+                - 'http://localhost:8080/${PATH_PREFIX:-/r/insights/platform}/${APP_NAME:-rhsm-conduit}/v1/status'
+            initialDelaySeconds: 45
             periodSeconds: 20
             successThreshold: 1
             timeoutSeconds: 3
@@ -66,8 +61,8 @@ objects:
               command:
                 - /usr/bin/curl
                 - '-s'
-                - 'http://localhost:8080/${${PATH_PREFIX:=/r/insights/platform}:+$PATH_PREFIX/}${APP_NAME:-rhsm-conduit}/v1/status/ready'
-            initialDelaySeconds: 90
+                - 'http://localhost:8080/${PATH_PREFIX:-/r/insights/platform}/${APP_NAME:-rhsm-conduit}/v1/status/ready'
+            initialDelaySeconds: 45
             periodSeconds: 20
             successThreshold: 1
             timeoutSeconds: 3

--- a/openshift/template_rhsm-conduit.yaml
+++ b/openshift/template_rhsm-conduit.yaml
@@ -46,22 +46,20 @@ objects:
                 key: database-password
           livenessProbe:
             failureThreshold: 3
-            exec:
-              command:
-                - /usr/bin/curl
-                - '-s'
-                - 'http://localhost:8080/${PATH_PREFIX:-/r/insights/platform}/${APP_NAME:-rhsm-conduit}/v1/status'
+            httpGet:
+              path: /actuator/health
+              port: 8080
+              scheme: HTTP
             initialDelaySeconds: 45
             periodSeconds: 20
             successThreshold: 1
             timeoutSeconds: 3
           readinessProbe:
             failureThreshold: 3
-            exec:
-              command:
-                - /usr/bin/curl
-                - '-s'
-                - 'http://localhost:8080/${PATH_PREFIX:-/r/insights/platform}/${APP_NAME:-rhsm-conduit}/v1/status/ready'
+            httpGet:
+              path: /actuator/health
+              port: 8080
+              scheme: HTTP
             initialDelaySeconds: 45
             periodSeconds: 20
             successThreshold: 1

--- a/src/main/resources/application.yaml
+++ b/src/main/resources/application.yaml
@@ -14,7 +14,6 @@ management:
       exposure:
         include:
           - health
-          - shutdown
           - prometheus
   endpoint:
     shutdown:

--- a/src/main/resources/rhsm-conduit.properties
+++ b/src/main/resources/rhsm-conduit.properties
@@ -1,16 +1,18 @@
 # Place application related defaults here.  This file is loaded via the @PropertySource annotation on the
 # ApplicationConfiguration class.  Prefix properties in this file appropriately (e.g. "rhsm-conduit") so the
 # classes annotated with @ConfigurationProperties will ingest them.
-server.servlet.context-path=${PATH_PREFIX:}
 rhsm-conduit.prettyPrintJson=false
-rhsm-conduit.package_uri_mappings.org.candlepin.insights=${APP_NAME:rhsm-conduit}/v1
 
-# Scheduled inventory updates
+# We're keeping the context-path as "/" so that the actuators we use for OKD liveness/readiness probes have a
+# fixed path.  The actual conduit resources will be configured to hang off of the path below.
+rhsm-conduit.package_uri_mappings.org.candlepin.insights=${PATH_PREFIX:/r/insights/platform}/${APP_NAME:rhsm-conduit}/v1
 rhsm-conduit.org-sync.schedule=0 */2 * * * ?
 rhsm-conduit.org-sync.strategy = fileBasedOrgListStrategy
 
 # Use Spring Resource notation for this (e.g. "classpath:" or "file:")
 rhsm-conduit.org-sync.fileBasedOrgListStrategy.org-resource-location=classpath:empty-org-list.txt
+
+rhsm-conduit.inventory-service.apiKey=changeit
 
 # Default Quartz datasource.  Override by pulling in another rhsm-conduit.properties file via an
 # -Dspring.config.additional-location argument


### PR DESCRIPTION
Double substitution works in zsh but not in bash!