### PR TITLE
Properly validate IP addresses

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -27,6 +27,7 @@ ext {
     junit_version = "5.3.2"
     slf4j_version = "1.7.25"
     mockito_version = "2.23.4"
+    guava_version="19.0"
 }
 
 allprojects {
@@ -102,6 +103,7 @@ dependencies {
         exclude group: "com.mchange", module: "c3p0"
         exclude group: "com.zaxxer", module: "HikariCP-java6"
     }
+    compile "com.google.guava:guava:$guava_version"
 
     // Runtime deps that will be included in the result package but not on the compile classpath.  I.e.
     // implementations of APIs we are using.

--- a/src/main/java/org/candlepin/insights/inventory/ConduitFacts.java
+++ b/src/main/java/org/candlepin/insights/inventory/ConduitFacts.java
@@ -20,6 +20,8 @@
  */
 package org.candlepin.insights.inventory;
 
+import org.candlepin.insights.validator.ip.IpAddress;
+
 import org.hibernate.validator.constraints.Length;
 
 import java.util.List;
@@ -36,8 +38,7 @@ public class ConduitFacts {
     private String biosUuid;
     private String orgId;
 
-    // This is a soft validation.  Bogus IP addresses like "999.999.999.999" will still validate
-    private List<@Pattern(regexp = "^\\d{1,3}\\.\\d{1,3}\\.\\d{1,3}\\.\\d{1,3}$") String> ipAddresses;
+    private List<@IpAddress String> ipAddresses;
 
     @Length(min = 1, max = 255)
 

--- a/src/main/java/org/candlepin/insights/validator/ip/IpAddress.java
+++ b/src/main/java/org/candlepin/insights/validator/ip/IpAddress.java
@@ -1,0 +1,67 @@
+/*
+ * Copyright (c) 2009 - 2019 Red Hat, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ *
+ * Red Hat trademarks are not licensed under GPLv3. No permission is
+ * granted to use or replicate Red Hat trademarks that are incorporated
+ * in this software or its documentation.
+ */
+package org.candlepin.insights.validator.ip;
+
+
+import static java.lang.annotation.ElementType.FIELD;
+import static java.lang.annotation.ElementType.TYPE_USE;
+import static java.lang.annotation.RetentionPolicy.RUNTIME;
+
+import org.candlepin.insights.validator.ip.IpAddress.List;
+
+import java.lang.annotation.Documented;
+import java.lang.annotation.Repeatable;
+import java.lang.annotation.Retention;
+import java.lang.annotation.Target;
+
+import javax.validation.Constraint;
+import javax.validation.Payload;
+
+/**
+ * Marks a field as needing V4/V6 IP validation. The annotation can be used on a String field
+ * or on a String typed collection.
+ * <pre>
+ * @IpAddress
+ * private String ip;
+ *
+ * private List<@IpAddress String> ipAddresses
+ * </pre>
+ */
+@Target({ FIELD, TYPE_USE })
+@Retention(RUNTIME)
+@Repeatable(List.class)
+@Documented
+@Constraint(validatedBy = { IpAddressValidator.class })
+public @interface IpAddress {
+    String message() default "Must be a valid IP address.";
+    Class<?>[] groups() default { };
+    Class<? extends Payload>[] payload() default { };
+
+    /**
+     * Inner annotation to support annotating type arguments of parameterized types.
+     */
+    @Target({ FIELD, TYPE_USE })
+    @Retention(RUNTIME)
+    @Documented
+    @interface List {
+        IpAddress[] value();
+    }
+}

--- a/src/main/java/org/candlepin/insights/validator/ip/IpAddressValidator.java
+++ b/src/main/java/org/candlepin/insights/validator/ip/IpAddressValidator.java
@@ -1,0 +1,46 @@
+/*
+ * Copyright (c) 2009 - 2019 Red Hat, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ *
+ * Red Hat trademarks are not licensed under GPLv3. No permission is
+ * granted to use or replicate Red Hat trademarks that are incorporated
+ * in this software or its documentation.
+ */
+package org.candlepin.insights.validator.ip;
+
+import com.google.common.net.InetAddresses;
+
+import javax.validation.ConstraintValidator;
+import javax.validation.ConstraintValidatorContext;
+
+/**
+ * A ConstraintValidator that ensures that an IP is a valid IPV4 or IPV6 IP.
+ */
+public class IpAddressValidator implements ConstraintValidator<IpAddress, String> {
+
+    @Override
+    public void initialize(IpAddress constraintAnnotation) {
+    }
+
+    @Override
+    public boolean isValid(String value, ConstraintValidatorContext context) {
+        // A null or empty value is considered invalid.
+        if (value == null || value.isEmpty()) {
+            return false;
+        }
+        return InetAddresses.isInetAddress(value);
+    }
+
+}

--- a/src/test/java/org/candlepin/insights/inventory/ConduitFactsTest.java
+++ b/src/test/java/org/candlepin/insights/inventory/ConduitFactsTest.java
@@ -47,13 +47,14 @@ public class ConduitFactsTest {
     public void testFactValidation() {
         ConduitFacts facts = new ConduitFacts();
         facts.setFqdn("");
+        facts.setIpAddresses(
+            Arrays.asList("192.168.2.1", "127.1", "::1", "1.1.1.", "1200::AB00:1234::2552:7777:1313"));
 
         Set<ConstraintViolation<ConduitFacts>> violations = validator.validate(facts);
-        assertThat(getFailingFields(violations), Matchers.hasItem("fqdn"));
-
-        facts.setIpAddresses(Arrays.asList("1.2"));
-        violations = validator.validate(facts);
-        assertThat(getFailingFields(violations), Matchers.hasItem(Matchers.startsWith("ipAddresses[0]")));
+        assertThat(getFailingFields(violations), Matchers.hasItems(
+            Matchers.startsWith("fqdn"),
+            Matchers.startsWith("ipAddresses[3]"),
+            Matchers.startsWith("ipAddresses[4]")));
     }
 
     private List<String> getFailingFields(Set<ConstraintViolation<ConduitFacts>> violations) {

--- a/src/test/java/org/candlepin/insights/validator/ip/IpAddressValidatorTest.java
+++ b/src/test/java/org/candlepin/insights/validator/ip/IpAddressValidatorTest.java
@@ -1,0 +1,96 @@
+/*
+ * Copyright (c) 2009 - 2019 Red Hat, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ *
+ * Red Hat trademarks are not licensed under GPLv3. No permission is
+ * granted to use or replicate Red Hat trademarks that are incorporated
+ * in this software or its documentation.
+ */
+package org.candlepin.insights.validator.ip;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import org.junit.jupiter.api.Test;
+
+public class IpAddressValidatorTest {
+
+    private IpAddressValidator validator = new IpAddressValidator();
+
+    @Test
+    public void testIpV4Validation() {
+        assertTrue(validator.isValid("192.168.2.1", null));
+    }
+
+    @Test
+    public void testInvalidIpV4Ip() {
+        assertFalse(validator.isValid("a.b.c.d", null));
+        assertFalse(validator.isValid("192.168.2.8.4", null));
+        assertFalse(validator.isValid("", null));
+        assertFalse(validator.isValid(null, null));
+        assertFalse(validator.isValid("129.2.2.z", null));
+        assertFalse(validator.isValid("129.2.2.", null));
+        assertFalse(validator.isValid(".129.2.2", null));
+        assertFalse(validator.isValid("192.500.2.4", null));
+        assertFalse(validator.isValid("redhat.com", null));
+        assertFalse(validator.isValid("myhost", null));
+        assertFalse(validator.isValid("999.3.3.3", null));
+    }
+
+    @Test
+    public void testIpV6Validation() {
+        // Standard notation
+        assertTrue(validator.isValid("1762:0:0:0:0:B03:1:AF18", null));
+
+        // Mixed notation
+        assertTrue(validator.isValid("1762:0:0:0:0:B03:127.32.67.15", null));
+
+        // Compressed notation
+        assertTrue(validator.isValid("::1", null));
+        assertTrue(validator.isValid("1762::B03:1:AF18", null));
+
+        // Compressed with variable number 0s
+        assertTrue(validator.isValid("1:0:0:0:0:6:0:0", null));
+        assertTrue(validator.isValid("1::6:0:0", null));
+        assertTrue(validator.isValid("1:0:0:0:0:6::", null));
+
+        // Compressed mixed notation
+        assertTrue(validator.isValid("1762::B03:127.32.67.15", null));
+    }
+
+    @Test
+    public void testInvalidIpV6() {
+        // Can only use :: once
+        assertFalse(validator.isValid("1200::AB00:1234::2552:7777:1313", null));
+
+        // Can't use O in all zeros
+        assertFalse(validator.isValid("1200:0000:AB00:1234:O000:2552:7777:1313", null));
+
+        // A -> F are valid, G is not.
+        assertFalse(validator.isValid("1762:0:0:0:0:G03:1:AF18", null));
+
+        // Invalid character
+        assertFalse(validator.isValid("2607:F380:A58:FFFF;0000:0000:0000:0001", null));
+        assertFalse(validator.isValid("2607:redhat.com", null));
+    }
+
+    @Test
+    public void caseInsensitiveIpV6() {
+        assertTrue(validator.isValid("2607:F380:A58:FFFF:0000:0000:0000:0001", null));
+        assertTrue(validator.isValid("2607:f380:a58:ffff:0000:0000:0000:0001", null));
+        assertTrue(validator.isValid("2607:f380:A58:FFfF:0000:0000:0000:0001", null));
+    }
+
+}


### PR DESCRIPTION
After updating the fact values from pinhead, IPV6 addresses were failing to validate causing hosts from pinhead to not get pushed to inventory.

I added a new validator to validate IP addresses that are set on ConduitFact.