### PR TITLE
Implement the debug endpoint

### DIFF
--- a/api/rhsm-conduit-api-spec.yaml
+++ b/api/rhsm-conduit-api-spec.yaml
@@ -168,39 +168,45 @@ components:
 
   schemas:
     ConsumerInventory:
-      # The properties list here will depend on what is returned
-      # from the IT endpoint.
+      # Container for fields we capture from the IT endpoint for upload to inventory service.
       required:
-        - consumer_uuid
-        - owner_account_key
+        - subscription_manager_id
+        - org_id
       properties:
-        id:
-          type: integer
-          format: int64
-        owner_account_key:
+        subscription_manager_id:
           type: string
-        hypervisor_host_name:
+        org_id:
           type: string
-        guest_hypervisor:
+        bios_uuid:
           type: string
-        guest_id:
-          type: string
-        installed_products:
-          type: object
-          additionalProperties:
+        ip_addresses:
+          type: array
+          items:
             type: string
+        fqdn:
+          type: string
+        mac_addresses:
+          type: array
+          items:
+            type: string
+        cpu_sockets:
+          type: integer
+        cpu_cores:
+          type: integer
         last_checkin:
           type: string
           format: date-time
-        consumer_type:
+        memory:
+          type: integer
+        architecture:
           type: string
-        system_purpose_facts:
-          type: object
-          additionalProperties:
-            type: string
-        consumer_facts:
-          type: object
-          additionalProperties:
+        is_virtual:
+          type: boolean
+        vm_host:
+          type: string
+        rh_prod:
+          type: array
+          items:
             type: string
 
     OrgInventory:

--- a/src/main/java/org/candlepin/insights/inventory/ConduitFacts.java
+++ b/src/main/java/org/candlepin/insights/inventory/ConduitFacts.java
@@ -20,149 +20,57 @@
  */
 package org.candlepin.insights.inventory;
 
+import org.candlepin.insights.api.model.ConsumerInventory;
 import org.candlepin.insights.validator.ip.IpAddress;
 
 import org.hibernate.validator.constraints.Length;
 
 import java.util.List;
 
+import javax.validation.Valid;
 import javax.validation.constraints.Pattern;
 import javax.validation.constraints.Positive;
 
 /**
- * POJO that holds all facts scoped for collection by the conduit.
+ * POJO that validates all facts scoped for collection by the conduit.
  */
-public class ConduitFacts {
-
-    private String subscriptionManagerId;
-    private String biosUuid;
-    private String orgId;
-
-    private List<@IpAddress String> ipAddresses;
+public class ConduitFacts extends ConsumerInventory {
 
     @Length(min = 1, max = 255)
+    @Override
+    public String getFqdn() {
+        return super.getFqdn();
+    }
 
-    private String fqdn;
+    @Valid
+    @Override
+    public List<@IpAddress String> getIpAddresses() {
+        return super.getIpAddresses();
+    }
 
     // See https://stackoverflow.com/a/4260512/6124862
     // Also a soft validation.  A mixed delimiter MAC like a1:b2-c3:d4-e5:f6 will still validate
-    private List<@Pattern(regexp = "^([0-9A-Fa-f]{2}[:-]){5}([0-9A-Fa-f]{2})$") String> macAddresses;
+    @Valid
+    @Override
+    public List<@Pattern(regexp = "^([0-9A-Fa-f]{2}[:-]){5}([0-9A-Fa-f]{2})$") String> getMacAddresses() {
+        return super.getMacAddresses();
+    }
 
     @Positive
-    private Integer cpuSockets;
-
-    @Positive
-    private Integer cpuCores;
-
-    @Positive
-    private Integer memory;
-
-    private String architecture;
-    private Boolean isVirtual;
-    private String vmHost;
-    private List<String> rhProd;
-
-    public String getSubscriptionManagerId() {
-        return subscriptionManagerId;
-    }
-
-    public void setSubscriptionManagerId(String subscriptionManagerId) {
-        this.subscriptionManagerId = subscriptionManagerId;
-    }
-
-    public String getBiosUuid() {
-        return biosUuid;
-    }
-
-    public String getOrgId() {
-        return orgId;
-    }
-
-    public void setOrgId(String orgId) {
-        this.orgId = orgId;
-    }
-
-    public void setBiosUuid(String biosUuid) {
-        this.biosUuid = biosUuid;
-    }
-
-    public List<String> getIpAddresses() {
-        return ipAddresses;
-    }
-
-    public void setIpAddresses(List<String> ipAddresses) {
-        this.ipAddresses = ipAddresses;
-    }
-
-    public String getFqdn() {
-        return fqdn;
-    }
-
-    public void setFqdn(String fqdn) {
-        this.fqdn = fqdn;
-    }
-
-    public List<String> getMacAddresses() {
-        return macAddresses;
-    }
-
-    public void setMacAddresses(List<String> macAddresses) {
-        this.macAddresses = macAddresses;
-    }
-
+    @Override
     public Integer getCpuSockets() {
-        return cpuSockets;
+        return super.getCpuSockets();
     }
 
-    public void setCpuSockets(Integer cpuSockets) {
-        this.cpuSockets = cpuSockets;
-    }
-
+    @Positive
+    @Override
     public Integer getCpuCores() {
-        return cpuCores;
+        return super.getCpuCores();
     }
 
-    public void setCpuCores(Integer cpuCores) {
-        this.cpuCores = cpuCores;
-    }
-
+    @Positive
+    @Override
     public Integer getMemory() {
-        return memory;
-    }
-
-    public void setMemory(Integer memory) {
-        this.memory = memory;
-    }
-
-    public String getArchitecture() {
-        return architecture;
-    }
-
-    public void setArchitecture(String architecture) {
-        this.architecture = architecture;
-    }
-
-    public String getVmHost() {
-        return vmHost;
-    }
-
-    public Boolean getVirtual() {
-        return isVirtual;
-    }
-
-    public void setVirtual(Boolean virtual) {
-        isVirtual = virtual;
-    }
-
-    public void setVmHost(String vmHost) {
-        this.vmHost = vmHost;
-    }
-
-    public List<String> getRhProd() {
-        return rhProd;
-    }
-
-    public void setRhProd(List<String> rhProd) {
-        this.rhProd = rhProd;
+        return super.getMemory();
     }
 }

--- a/src/main/java/org/candlepin/insights/inventory/InventoryService.java
+++ b/src/main/java/org/candlepin/insights/inventory/InventoryService.java
@@ -20,6 +20,8 @@
  */
 package org.candlepin.insights.inventory;
 
+import org.candlepin.insights.api.model.ConsumerInventory;
+import org.candlepin.insights.api.model.OrgInventory;
 import org.candlepin.insights.exception.RhsmConduitException;
 import org.candlepin.insights.exception.inventory.InventoryServiceException;
 import org.candlepin.insights.inventory.client.model.BulkHostOut;
@@ -30,6 +32,7 @@ import org.candlepin.insights.inventory.client.resources.HostsApi;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Component;
 
+import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.LinkedList;
 import java.util.List;
@@ -86,8 +89,8 @@ public class InventoryService {
         if (conduitFacts.getArchitecture() != null) {
             rhsmFactMap.put("ARCHITECTURE", conduitFacts.getArchitecture());
         }
-        if (conduitFacts.getVirtual() != null) {
-            rhsmFactMap.put("IS_VIRTUAL", conduitFacts.getVirtual());
+        if (conduitFacts.getIsVirtual() != null) {
+            rhsmFactMap.put("IS_VIRTUAL", conduitFacts.getIsVirtual());
         }
         if (conduitFacts.getVmHost() != null) {
             rhsmFactMap.put("VM_HOST", conduitFacts.getVmHost());
@@ -113,4 +116,8 @@ public class InventoryService {
         return host;
     }
 
+    public OrgInventory getInventoryForOrgConsumers(List<ConduitFacts> conduitFactsForOrg) {
+        List<ConsumerInventory> hosts = new ArrayList<>(conduitFactsForOrg);
+        return new OrgInventory().consumerInventories(hosts);
+    }
 }

--- a/src/test/java/org/candlepin/insights/controller/InventoryControllerTest.java
+++ b/src/test/java/org/candlepin/insights/controller/InventoryControllerTest.java
@@ -95,7 +95,7 @@ public class InventoryControllerTest {
         assertEquals(Arrays.asList("00:00:00:00:00:00", "ff:ff:ff:ff:ff:ff"), conduitFacts.getMacAddresses());
         assertEquals(new Integer(2), conduitFacts.getCpuSockets());
         assertEquals("x86_64", conduitFacts.getArchitecture());
-        assertTrue(conduitFacts.getVirtual());
+        assertTrue(conduitFacts.getIsVirtual());
     }
 
     @Test

--- a/src/test/java/org/candlepin/insights/inventory/InventoryServiceTest.java
+++ b/src/test/java/org/candlepin/insights/inventory/InventoryServiceTest.java
@@ -1,0 +1,98 @@
+/*
+ * Copyright (c) 2009 - 2019 Red Hat, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ *
+ * Red Hat trademarks are not licensed under GPLv3. No permission is
+ * granted to use or replicate Red Hat trademarks that are incorporated
+ * in this software or its documentation.
+ */
+package org.candlepin.insights.inventory;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+import org.candlepin.insights.api.model.OrgInventory;
+import org.candlepin.insights.inventory.client.ApiException;
+import org.candlepin.insights.inventory.client.model.CreateHostIn;
+import org.candlepin.insights.inventory.client.model.FactSet;
+import org.candlepin.insights.inventory.client.resources.HostsApi;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.Mockito;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.Map;
+
+@ExtendWith(MockitoExtension.class)
+public class InventoryServiceTest {
+    @Mock
+    HostsApi api;
+
+    private ConduitFacts createFullyPopulatedConduitFacts() {
+        ConduitFacts conduitFacts = new ConduitFacts();
+        conduitFacts.setArchitecture("x86_64");
+        conduitFacts.setBiosUuid("9d9f7927-1f42-4827-bbb8-1791b2b0a1b4");
+        conduitFacts.setCpuCores(8);
+        conduitFacts.setCpuSockets(4);
+        conduitFacts.setFqdn("test.example.com");
+        conduitFacts.setIpAddresses(Collections.singletonList("127.0.0.1"));
+        conduitFacts.setMacAddresses(Collections.singletonList("de:ad:be:ef:fe:ed"));
+        conduitFacts.setMemory(32757752);
+        conduitFacts.setOrgId("1234-org");
+        conduitFacts.setRhProd(Collections.singletonList("72"));
+        conduitFacts.setSubscriptionManagerId("108152b1-6b41-4e1b-b908-922c943e7950");
+        conduitFacts.setIsVirtual(true);
+        conduitFacts.setVmHost("vm_host");
+        return conduitFacts;
+    }
+
+    @Test
+    public void testSendHostUpdatePopulatesAllFieldsWithFullConduitFactsRecord() throws ApiException {
+        InventoryService inventoryService = new InventoryService(api);
+        inventoryService.sendHostUpdate(Collections.singletonList(createFullyPopulatedConduitFacts()));
+        Map<String, Object> expectedFactMap = new HashMap<>();
+        expectedFactMap.put("CPU_SOCKETS", 4);
+        expectedFactMap.put("CPU_CORES", 8);
+        expectedFactMap.put("MEMORY", 32757752);
+        expectedFactMap.put("ARCHITECTURE", "x86_64");
+        expectedFactMap.put("IS_VIRTUAL", true);
+        expectedFactMap.put("VM_HOST", "vm_host");
+        expectedFactMap.put("RH_PROD", Collections.singletonList("72"));
+        expectedFactMap.put("orgId", "1234-org");
+        FactSet expectedFacts = new FactSet().namespace("rhsm").facts(expectedFactMap);
+        CreateHostIn expectedHostEntry = new CreateHostIn()
+            .account("1234-org")
+            .biosUuid("9d9f7927-1f42-4827-bbb8-1791b2b0a1b4")
+            .ipAddresses(Collections.singletonList("127.0.0.1"))
+            .macAddresses(Collections.singletonList("de:ad:be:ef:fe:ed"))
+            .subscriptionManagerId("108152b1-6b41-4e1b-b908-922c943e7950")
+            .fqdn("test.example.com")
+            .facts(Collections.singletonList(expectedFacts));
+        Mockito.verify(api).apiHostAddHostList(Mockito.eq(Collections.singletonList(expectedHostEntry)));
+    }
+
+    @Test
+    public void testGetInventoryForOrgConsumersContainsEquivalentConsumerInventory() {
+        InventoryService inventoryService = new InventoryService(null);
+        ConduitFacts conduitFacts = createFullyPopulatedConduitFacts();
+        OrgInventory orgInventory = inventoryService
+            .getInventoryForOrgConsumers(Collections.singletonList(conduitFacts));
+        assertEquals(1, orgInventory.getConsumerInventories().size());
+        assertEquals(conduitFacts, orgInventory.getConsumerInventories().get(0));
+    }
+}

--- a/src/test/java/org/candlepin/insights/resource/InventoriesResourceTest.java
+++ b/src/test/java/org/candlepin/insights/resource/InventoriesResourceTest.java
@@ -20,39 +20,34 @@
  */
 package org.candlepin.insights.resource;
 
-import org.candlepin.insights.api.model.OrgInventory;
-import org.candlepin.insights.api.resources.InventoriesApi;
 import org.candlepin.insights.controller.InventoryController;
 import org.candlepin.insights.task.TaskManager;
 
-import org.springframework.stereotype.Component;
-import org.springframework.validation.annotation.Validated;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.Mockito;
+import org.mockito.junit.jupiter.MockitoExtension;
 
-import javax.validation.constraints.NotNull;
+@ExtendWith(MockitoExtension.class)
+class InventoriesResourceTest {
+    @Mock
+    InventoryController controller;
 
+    @Mock
+    TaskManager manager;
 
-/**
- * The inventories API implementation.
- */
-@Component
-@Validated
-public class InventoriesResource implements InventoriesApi {
-
-    private final InventoryController inventoryController;
-    private final TaskManager tasks;
-
-    public InventoriesResource(InventoryController inventoryController, TaskManager tasks) {
-        this.inventoryController = inventoryController;
-        this.tasks = tasks;
+    @Test
+    void testGetInventoryCallsInventoryController() {
+        InventoriesResource inventories = new InventoriesResource(controller, manager);
+        inventories.getInventoryForOrg(new byte[]{}, "org-1234");
+        Mockito.verify(controller).getInventoryForOrg(Mockito.eq("org-1234"));
     }
 
-    @Override
-    public OrgInventory getInventoryForOrg(@NotNull byte[] xRhIdentity, String orgId) {
-        return inventoryController.getInventoryForOrg(orgId);
-    }
-
-    @Override
-    public void updateInventoryForOrg(@NotNull byte[] xRhIdentity, String orgId) {
-        tasks.updateOrgInventory(orgId);
+    @Test
+    void testUpdateInventoryDelegatesToTask() {
+        InventoriesResource inventories = new InventoriesResource(controller, manager);
+        inventories.updateInventoryForOrg(new byte[]{}, "org-1234");
+        Mockito.verify(manager).updateOrgInventory(Mockito.eq("org-1234"));
     }
 }


### PR DESCRIPTION
With this change the debug endpoint accurately reflects what would be sent to the inventory service.

Since we control the interface for it, I decided that ConsumerInventory should reflect our service's view of a consumer generally, and then realized that there was a great deal of overlap with ConduitFacts.

Since the validation provided by ConduitFacts has been valuable, I reworked it to be a subclass of ConsumerInventory.

With this in place, `curl localhost:8080/rhsm-conduit/v1/inventories/1234` (or similar) is useful.