### PR TITLE
Insert git reference into Spring Boot build info & add release plugin

### DIFF
--- a/README.md
+++ b/README.md
@@ -132,6 +132,26 @@ extended. Please see the
 [documentation](https://docs.spring.io/spring-boot/docs/current/reference/html/production-ready-endpoints.html)
 for a discussion of extension points.
 
+## Release Notes
+
+You can perform a release using `./gradlew release` **on the master
+branch**. This command will invoke a
+[plugin](https://github.com/researchgate/gradle-release) that will bump
+the version numbers and create a release tag. When you run the command,
+it will ask for input. You can specify all the arguments on the CLI if
+necessary (e.g. doing a release via a CI environment). When asked for
+"This release version" specify the current version **without** the
+"-SNAPSHOT". When asked for the next version number enter the
+appropriate value prefixed **with** "-SNAPSHOT". The plugin should offer
+sane defaults that you can use.
+
+For example. If we are working on `1.0.0-SNAPSHOT`, you would answer the
+first question with `1.0.0` and the second question with
+`1.0.1-SNAPSHOT`.
+
+The plugin will create the tag and bump the version. You just need to
+push with `git push --follow-tags origin master`.
+
 ## Kafka
 
 See the detailed notes [here](README-kafka.md)

--- a/build.gradle
+++ b/build.gradle
@@ -13,6 +13,7 @@ plugins {
     id "jacoco"
     id "org.sonarqube" version "2.7"
     id "org.springframework.boot" version "2.0.8.RELEASE"
+    id "net.researchgate.release" version "2.6.0"
 }
 
 ext {
@@ -60,8 +61,6 @@ allprojects {
     }
 }
 
-version = "1.0.0"
-
 bootJar {
     mainClassName = "org.candlepin.insights.BootApplication"
 }
@@ -80,6 +79,14 @@ springBoot {
             ]
         }
     }
+}
+
+release {
+    // Use single quotes so the variables aren't interpreted in the build file itself!
+    tagTemplate = '${name}-${version}'
+    preTagCommitMessage = '[RHSM Conduit Release] - pre tag commit: '
+    tagCommitMessage = '[RHSM Conduit Release] - creating tag: '
+    newVersionCommitMessage = '[RHSM Conduit Release] - version bump: '
 }
 
 dependencies {

--- a/build.gradle
+++ b/build.gradle
@@ -1,5 +1,3 @@
-import org.apache.tools.ant.filters.ReplaceTokens
-
 buildscript {
     repositories {
         mavenLocal()

--- a/build.gradle
+++ b/build.gradle
@@ -74,8 +74,9 @@ springBoot {
             // https://docs.spring.io/spring-boot/docs/2.1.4.RELEASE/gradle-plugin/reference/html/#integrating-with-actuator
             time = null
             additional = [
-                    'spring version': spring_version,
-                    'spring-boot version': spring_boot_version
+                    // --first-parent means git describe won't look at tags that are on merged branches
+                    'gitDescription': "git describe --always --first-parent".execute().text.trim(),
+                    'gitHash': "git rev-parse HEAD".execute().text.trim()
             ]
         }
     }

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,0 +1,1 @@
+version = 1.0.0-SNAPSHOT


### PR DESCRIPTION
Adding the git reference (and the git "description" for better human
readability) will let QA people report the exact version of the code
causing an error.

Also adds a "release" plugin that is basically like Tito but for Gradle.

You can practice the release yourself like so:

```
$ git remote rm origin  # avoid pushing any boo-boos
$ git checkout master
$ git reset --hard awood/actuators
$ ./gradlew release
...
$ # To clean up
$ git tag -d rhsm-conduit-1.0.0
$ git remote add -f origin git@github.com:RedHatInsights/rhsm-conduit
$ git reset --hard origin/master
```

I can't quite figure why the commit message on the tag commit is "[RHSM Conduit Release] - pre tag commit: " instead of "[RHSM Conduit Release] - creating tag: " and the [plugin code](https://github.com/researchgate/gradle-release/blob/master/src/main/groovy/net/researchgate/release/ReleasePlugin.groovy) didn't illuminate anything for me.  I'm not sure how big a worry a slightly weird commit message is.  We can always change the message but it indicates to me that the plugin is behaving differently from how one would expect.
