### PR TITLE
Request 200m-300m cpu & 100M-500M memory

### DIFF
--- a/openshift/template_rhsm-conduit.yaml
+++ b/openshift/template_rhsm-conduit.yaml
@@ -64,6 +64,13 @@ objects:
             periodSeconds: 20
             successThreshold: 1
             timeoutSeconds: 3
+          resources:
+            requests:
+              cpu: 200m
+              memory: 100Mi
+            limits:
+              cpu: 300m
+              memory: 500Mi
           ports:
           - containerPort: 8080
             protocol: TCP


### PR DESCRIPTION
Meaning the container will be guaranteed 200m CPU & 100M memory, but may
use up to 300m CPU & 500M memory if that much is free. We can adjust
this later if necessary.