### PR TITLE
Use Spring's ResourceHandler functionality to serve openapi specs.

### DIFF
--- a/src/main/java/org/candlepin/insights/ApplicationConfiguration.java
+++ b/src/main/java/org/candlepin/insights/ApplicationConfiguration.java
@@ -43,6 +43,7 @@ import org.springframework.context.annotation.Primary;
 import org.springframework.context.annotation.PropertySource;
 import org.springframework.validation.beanvalidation.LocalValidatorFactoryBean;
 import org.springframework.validation.beanvalidation.MethodValidationPostProcessor;
+import org.springframework.web.servlet.config.annotation.ResourceHandlerRegistry;
 import org.springframework.web.servlet.config.annotation.ViewControllerRegistry;
 import org.springframework.web.servlet.config.annotation.WebMvcConfigurer;
 
@@ -63,6 +64,7 @@ public class ApplicationConfiguration implements WebMvcConfigurer {
 
     @Autowired
     private ApplicationProperties applicationProperties;
+
 
      /**
      * Used to set context-param values since Spring Boot does not have a web.xml.  Technically
@@ -182,4 +184,11 @@ public class ApplicationConfiguration implements WebMvcConfigurer {
         registry.addViewController("/api-docs/").setViewName("redirect:/api-docs/index.html");
     }
 
+    @Override
+    public void addResourceHandlers(ResourceHandlerRegistry registry) {
+        registry.addResourceHandler("/api-docs/openapi.*").addResourceLocations(
+            "classpath:openapi.yaml",
+            "classpath:openapi.json"
+        );
+    }
 }

--- a/src/main/resources/static/api-docs/index.html
+++ b/src/main/resources/static/api-docs/index.html
@@ -14,7 +14,7 @@
     window.onload = function() {
       // Begin Swagger UI call region
       const ui = SwaggerUIBundle({
-        url: "../rhsm-conduit/v1/openapi.yaml",
+        url: "openapi.yaml",
         dom_id: '#swagger-ui',
         deepLinking: true,
         presets: [


### PR DESCRIPTION
This fixes an issue where the `/api-docs/index.html` wasn't actually working.  The page wasn't working because the underlying javascript was attempting to load `url: "../rhsm-conduit/v1/openapi.yaml` which did not take into account the entire application context we use: "/r/insights/platform/rhsm-conduit/v1" (in most cases).

**Testing**
*Setup*
1. Deploy the application.  `./gradlew bootRun --args="--server.port=9166"`
2. Visit http://localhost:9166/api-docs/index.html

*Before*
* Observe the page reads "No API definition provided" and your webdeveloper tools will show a 404 when the JS attempted to fetch the openapi.yaml file

*After*
* The API page displays successfully
