### PR TITLE
Update openapi-generator to 4.0.1

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -4,7 +4,7 @@ buildscript {
         mavenCentral()
     }
     dependencies {
-        classpath "org.openapitools:openapi-generator-gradle-plugin:4.0.0-beta"
+        classpath "org.openapitools:openapi-generator-gradle-plugin:4.0.1"
     }
 }
 


### PR DESCRIPTION
Fixes an issue related to OpenApiTools/openapi-generator#1714, which we were encountering with the latest host inventory spec.