### PR TITLE
Use default Java truststore if one is not defined via config.

### DIFF
--- a/pinhead-client/src/main/java/org/candlepin/insights/pinhead/client/X509ApiClientFactoryConfiguration.java
+++ b/pinhead-client/src/main/java/org/candlepin/insights/pinhead/client/X509ApiClientFactoryConfiguration.java
@@ -108,6 +108,10 @@ public class X509ApiClientFactoryConfiguration {
         return (getKeystoreFile() != null && getKeystorePassword() != null);
     }
 
+    public boolean usesDefaultTruststore() {
+        return getTruststoreFile() == null;
+    }
+
     public String toString() {
         return String.format("X509ApiClientFactoryConfiguration[truststore=%s, keystore=%s]",
             truststoreFile, keystoreFile);


### PR DESCRIPTION
Also, remove use of Google utility class (which is marked as unstable)
for loading test resources.  Spring provides similar functionality.