### PR TITLE
Omit empty fields in host inventory client

### DIFF
--- a/insights-inventory-client/src/main/java/org/candlepin/insights/inventory/client/HostsApiFactory.java
+++ b/insights-inventory-client/src/main/java/org/candlepin/insights/inventory/client/HostsApiFactory.java
@@ -22,6 +22,9 @@ package org.candlepin.insights.inventory.client;
 
 import org.candlepin.insights.inventory.client.resources.HostsApi;
 
+import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.databind.ObjectMapper;
+
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.FactoryBean;
@@ -59,6 +62,8 @@ public class HostsApiFactory implements FactoryBean<HostsApi> {
         if (apiKey == null || apiKey.isEmpty()) {
             throw new IllegalStateException("No api key has been set for the inventory client.");
         }
+        ObjectMapper mapper = apiClient.getJSON().getContext(ObjectMapper.class);
+        mapper.setSerializationInclusion(JsonInclude.Include.NON_EMPTY);
         apiClient.addDefaultHeader("Authorization", String.format("Bearer %s", apiKey));
 
         return new HostsApi(apiClient);

--- a/src/main/java/org/candlepin/insights/jackson/ObjectMapperContextResolver.java
+++ b/src/main/java/org/candlepin/insights/jackson/ObjectMapperContextResolver.java
@@ -36,6 +36,11 @@ import javax.ws.rs.ext.Provider;
  * A ContextResolver responsible for customizing the configuration of Jackson's
  * ObjectMapper instance. This is marked as a Provider so that RestEasy will
  * use the configured ObjectMapper provided by this instance.
+ *
+ * NOTE: this class is responsible for the server's serialization/deserialization only.
+ * Configuration of the ObjectMapper used in the clients is mostly done in the ApiClient classes, and we can
+ * customize them via <pre>apiClient.getJSON().getContext(ObjectMapper.class)</pre> (see
+ * {@link org.candlepin.insights.inventory.client.HostsApiFactory} for an example).
  */
 @Provider
 public class ObjectMapperContextResolver implements ContextResolver<ObjectMapper> {


### PR DESCRIPTION
Apparently the `ApiClient` classes create their own `ObjectMapper`
instances, and thus we need to customize them differently.

I also added a comment in ObjectMapperContextResolver to explain this.