### PR TITLE
Support creating/updating inventory hosts via Kafka

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,8 +2,11 @@
 
 ## Deploy insights-inventory
 
-rhsm-conduit requires a connection to insights-inventory. First set up a
-postgres user and database.
+### Local Install Via Our Custom Script
+
+NOTE: As of right now, our scripts do not support configuring insights inventory kafka message service.
+
+First set up a postgres user and database.
 
 ```
 su - postgres
@@ -24,6 +27,40 @@ command if you used a different port for deployment).
 ```
 curl http://localhost:8080/metrics
 ```
+
+### Install Via Docker
+
+Insights inventory makes it pretty straightforward to install all components via docker.
+
+**NOTE: The supporting code for this is NOT currently checked into the inventory service's master branch. You will
+need to check out the ```origin/split_inventory_service``` branch.**
+
+
+1. Start a kafka and DB instance (unless you reconfigure the scripts you will need to stop your local postgres instance)
+    ```
+    $ docker-compose -f dev.yml up
+    ```
+
+1. Prep the inventory database
+```
+make upgrade_db
+```
+
+1. Add a host entry in ```/etc/hosts``` pointing to the kafka instance that is running on localhost:
+    ```
+    127.0.0.1      kafka
+    ```
+
+1. Run the kafka host message listener service:
+    ```
+    $ make run_inv_mq_service
+    ```
+
+1. Run the inventory web service
+    ```
+    $ make run_inv_web_service
+    ```
+
 
 ## Build and Run rhsm-conduit
 

--- a/insights-inventory-client/src/main/java/org/candlepin/insights/inventory/client/InventoryServiceProperties.java
+++ b/insights-inventory-client/src/main/java/org/candlepin/insights/inventory/client/InventoryServiceProperties.java
@@ -27,6 +27,8 @@ public class InventoryServiceProperties {
     private boolean useStub;
     private String url;
     private String apiKey;
+    private boolean enableKafka;
+    private String kafkaHostIngressTopic = "platform.inventory.host-ingress";
 
     public boolean isUseStub() {
         return useStub;
@@ -50,5 +52,21 @@ public class InventoryServiceProperties {
 
     public void setApiKey(String apiKey) {
         this.apiKey = apiKey;
+    }
+
+    public boolean isEnableKafka() {
+        return enableKafka;
+    }
+
+    public void setEnableKafka(boolean enableKafka) {
+        this.enableKafka = enableKafka;
+    }
+
+    public String getKafkaHostIngressTopic() {
+        return kafkaHostIngressTopic;
+    }
+
+    public void setKafkaHostIngressTopic(String kafkaHostIngressTopic) {
+        this.kafkaHostIngressTopic = kafkaHostIngressTopic;
     }
 }

--- a/pinhead-client/src/main/java/org/candlepin/insights/pinhead/client/StubPinheadApi.java
+++ b/pinhead-client/src/main/java/org/candlepin/insights/pinhead/client/StubPinheadApi.java
@@ -43,6 +43,7 @@ public class StubPinheadApi extends PinheadApi {
         Consumer consumer1 = new Consumer();
         consumer1.setUuid(UUID.randomUUID().toString());
         consumer1.setOrgId(orgId);
+        consumer1.setAccountNumber("ACCOUNT_1");
         consumer1.setHypervisorName("hypervisor1.test.com");
         consumer1.getFacts().put("network.fqdn", "host1.test.com");
         consumer1.getFacts().put("dmi.system.uuid", UUID.randomUUID().toString());
@@ -60,6 +61,7 @@ public class StubPinheadApi extends PinheadApi {
         Consumer consumer2 = new Consumer();
         consumer2.setUuid(UUID.randomUUID().toString());
         consumer2.setOrgId(orgId);
+        consumer2.setAccountNumber("ACCOUNT_1");
         consumer2.getFacts().put("network.fqdn", "host2.test.com");
 
         inventory.getFeeds().add(consumer1);

--- a/src/main/java/org/candlepin/insights/ApplicationConfiguration.java
+++ b/src/main/java/org/candlepin/insights/ApplicationConfiguration.java
@@ -20,8 +20,6 @@
  */
 package org.candlepin.insights;
 
-import org.candlepin.insights.inventory.client.HostsApiFactory;
-import org.candlepin.insights.inventory.client.InventoryServiceProperties;
 import org.candlepin.insights.jackson.ObjectMapperContextResolver;
 import org.candlepin.insights.pinhead.client.PinheadApiFactory;
 import org.candlepin.insights.pinhead.client.PinheadApiProperties;
@@ -109,17 +107,6 @@ public class ApplicationConfiguration implements WebMvcConfigurer {
     @Bean
     public PinheadApiFactory pinheadApiFactory(PinheadApiProperties properties) {
         return new PinheadApiFactory(properties);
-    }
-
-    @Bean
-    @ConfigurationProperties(prefix = "rhsm-conduit.inventory-service")
-    public InventoryServiceProperties inventoryServiceProperties() {
-        return new InventoryServiceProperties();
-    }
-
-    @Bean
-    public HostsApiFactory hostsApiFactory(InventoryServiceProperties properties) {
-        return new HostsApiFactory(properties);
     }
 
     @Bean

--- a/src/main/java/org/candlepin/insights/controller/InventoryController.java
+++ b/src/main/java/org/candlepin/insights/controller/InventoryController.java
@@ -23,7 +23,6 @@ package org.candlepin.insights.controller;
 import org.candlepin.insights.api.model.OrgInventory;
 import org.candlepin.insights.inventory.ConduitFacts;
 import org.candlepin.insights.inventory.InventoryService;
-import org.candlepin.insights.inventory.client.model.BulkHostOut;
 import org.candlepin.insights.orgsync.OrgListStrategy;
 import org.candlepin.insights.pinhead.PinheadService;
 import org.candlepin.insights.pinhead.client.model.Consumer;
@@ -225,9 +224,8 @@ public class InventoryController {
 
     public void updateInventoryForOrg(String orgId) {
         List<ConduitFacts> conduitFactsForOrg = getValidatedConsumers(orgId);
-        BulkHostOut result = inventoryService.sendHostUpdate(conduitFactsForOrg);
+        inventoryService.sendHostUpdate(conduitFactsForOrg);
         log.info("Host inventory update completed for org: {}", orgId);
-        log.debug("Results for org {}: {}", orgId, result);
     }
 
     public OrgInventory getInventoryForOrg(String orgId) {

--- a/src/main/java/org/candlepin/insights/inventory/DefaultInventoryService.java
+++ b/src/main/java/org/candlepin/insights/inventory/DefaultInventoryService.java
@@ -1,0 +1,146 @@
+/*
+ * Copyright (c) 2009 - 2019 Red Hat, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ *
+ * Red Hat trademarks are not licensed under GPLv3. No permission is
+ * granted to use or replicate Red Hat trademarks that are incorporated
+ * in this software or its documentation.
+ */
+package org.candlepin.insights.inventory;
+
+import org.candlepin.insights.api.model.ConsumerInventory;
+import org.candlepin.insights.api.model.OrgInventory;
+import org.candlepin.insights.exception.inventory.InventoryServiceException;
+import org.candlepin.insights.inventory.client.model.BulkHostOut;
+import org.candlepin.insights.inventory.client.model.CreateHostIn;
+import org.candlepin.insights.inventory.client.model.FactSet;
+import org.candlepin.insights.inventory.client.resources.HostsApi;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.time.OffsetDateTime;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.LinkedList;
+import java.util.List;
+import java.util.Map;
+import java.util.stream.Collectors;
+
+
+/**
+ * A wrapper for the insights inventory client.
+ *
+ * If we get to the point where we are making multiple manipulations to the data stream as it flows through
+ * this class consider
+ * <code>
+ * public interface ConduitVisitor {
+ *     default FactSet visit(FactSet factSet) {
+ *         return factSet;
+ *     }
+ *
+ *     default CreateHostIn visit(CreateHostIn createHostIn) {
+ *         return createHostIn;
+ *     }
+ *
+ *     default BulkHostOut visit(BulkHostOut bulkHostOut) {
+ *         return bulkHostOut;
+ *     }
+ * </code>
+ *
+ * The visit methods can then get called at the appropriate places in sendHostUpdate and createHost
+ * allowing us to externalize manipulations to the implementation(s) of ConduitVisitor.
+ */
+public class DefaultInventoryService implements InventoryService {
+    private static final Logger log = LoggerFactory.getLogger(DefaultInventoryService.class);
+
+    private final HostsApi hostsInventoryApi;
+
+    public DefaultInventoryService(HostsApi hostsInventoryApi) {
+        this.hostsInventoryApi = hostsInventoryApi;
+    }
+
+    public void sendHostUpdate(List<ConduitFacts> facts) {
+
+        // The same timestamp for the whole batch
+        OffsetDateTime now = OffsetDateTime.now();
+        List<CreateHostIn> hostsToSend = facts.stream()
+            .map(x -> createHost(x, now))
+            .collect(Collectors.toList());
+
+        try {
+            BulkHostOut hosts = hostsInventoryApi.apiHostAddHostList(hostsToSend);
+            log.debug("Finished updating hosts: {}", hosts);
+        }
+        catch (Exception e) {
+            throw new InventoryServiceException(
+                "An error occurred while sending a host update to the inventory service.", e);
+        }
+    }
+
+    /**
+     * Given a set of facts, report them as a host to the inventory service.
+     *
+     * @return the new host.
+     */
+    protected CreateHostIn createHost(ConduitFacts conduitFacts, OffsetDateTime syncTimestamp) {
+        Map<String, Object> rhsmFactMap = new HashMap<>();
+        rhsmFactMap.put("orgId", conduitFacts.getOrgId());
+        if (conduitFacts.getCpuSockets() != null) {
+            rhsmFactMap.put("CPU_SOCKETS", conduitFacts.getCpuSockets());
+        }
+        if (conduitFacts.getCpuCores() != null) {
+            rhsmFactMap.put("CPU_CORES", conduitFacts.getCpuCores());
+        }
+        if (conduitFacts.getMemory() != null) {
+            rhsmFactMap.put("MEMORY", conduitFacts.getMemory());
+        }
+        if (conduitFacts.getArchitecture() != null) {
+            rhsmFactMap.put("ARCHITECTURE", conduitFacts.getArchitecture());
+        }
+        if (conduitFacts.getIsVirtual() != null) {
+            rhsmFactMap.put("IS_VIRTUAL", conduitFacts.getIsVirtual());
+        }
+        if (conduitFacts.getVmHost() != null) {
+            rhsmFactMap.put("VM_HOST", conduitFacts.getVmHost());
+        }
+        if (conduitFacts.getRhProd() != null) {
+            rhsmFactMap.put("RH_PROD", conduitFacts.getRhProd());
+        }
+
+        rhsmFactMap.put("SYNC_TIMESTAMP", syncTimestamp);
+
+        FactSet rhsmFacts = new FactSet()
+            .namespace("rhsm")
+            .facts(rhsmFactMap);
+        List<FactSet> facts = new LinkedList<>();
+        facts.add(rhsmFacts);
+
+        CreateHostIn host = new CreateHostIn();
+        host.setAccount(conduitFacts.getAccountNumber());
+        host.setFqdn(conduitFacts.getFqdn());
+        host.setSubscriptionManagerId(conduitFacts.getSubscriptionManagerId());
+        host.setBiosUuid(conduitFacts.getBiosUuid());
+        host.setIpAddresses(conduitFacts.getIpAddresses());
+        host.setMacAddresses(conduitFacts.getMacAddresses());
+        host.facts(facts);
+        return host;
+    }
+
+    public OrgInventory getInventoryForOrgConsumers(List<ConduitFacts> conduitFactsForOrg) {
+        List<ConsumerInventory> hosts = new ArrayList<>(conduitFactsForOrg);
+        return new OrgInventory().consumerInventories(hosts);
+    }
+}

--- a/src/main/java/org/candlepin/insights/inventory/DefaultInventoryService.java
+++ b/src/main/java/org/candlepin/insights/inventory/DefaultInventoryService.java
@@ -20,23 +20,16 @@
  */
 package org.candlepin.insights.inventory;
 
-import org.candlepin.insights.api.model.ConsumerInventory;
-import org.candlepin.insights.api.model.OrgInventory;
 import org.candlepin.insights.exception.inventory.InventoryServiceException;
 import org.candlepin.insights.inventory.client.model.BulkHostOut;
 import org.candlepin.insights.inventory.client.model.CreateHostIn;
-import org.candlepin.insights.inventory.client.model.FactSet;
 import org.candlepin.insights.inventory.client.resources.HostsApi;
 
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import java.time.OffsetDateTime;
-import java.util.ArrayList;
-import java.util.HashMap;
-import java.util.LinkedList;
 import java.util.List;
-import java.util.Map;
 import java.util.stream.Collectors;
 
 
@@ -63,7 +56,7 @@ import java.util.stream.Collectors;
  * The visit methods can then get called at the appropriate places in sendHostUpdate and createHost
  * allowing us to externalize manipulations to the implementation(s) of ConduitVisitor.
  */
-public class DefaultInventoryService implements InventoryService {
+public class DefaultInventoryService extends InventoryService {
     private static final Logger log = LoggerFactory.getLogger(DefaultInventoryService.class);
 
     private final HostsApi hostsInventoryApi;
@@ -90,57 +83,4 @@ public class DefaultInventoryService implements InventoryService {
         }
     }
 
-    /**
-     * Given a set of facts, report them as a host to the inventory service.
-     *
-     * @return the new host.
-     */
-    protected CreateHostIn createHost(ConduitFacts conduitFacts, OffsetDateTime syncTimestamp) {
-        Map<String, Object> rhsmFactMap = new HashMap<>();
-        rhsmFactMap.put("orgId", conduitFacts.getOrgId());
-        if (conduitFacts.getCpuSockets() != null) {
-            rhsmFactMap.put("CPU_SOCKETS", conduitFacts.getCpuSockets());
-        }
-        if (conduitFacts.getCpuCores() != null) {
-            rhsmFactMap.put("CPU_CORES", conduitFacts.getCpuCores());
-        }
-        if (conduitFacts.getMemory() != null) {
-            rhsmFactMap.put("MEMORY", conduitFacts.getMemory());
-        }
-        if (conduitFacts.getArchitecture() != null) {
-            rhsmFactMap.put("ARCHITECTURE", conduitFacts.getArchitecture());
-        }
-        if (conduitFacts.getIsVirtual() != null) {
-            rhsmFactMap.put("IS_VIRTUAL", conduitFacts.getIsVirtual());
-        }
-        if (conduitFacts.getVmHost() != null) {
-            rhsmFactMap.put("VM_HOST", conduitFacts.getVmHost());
-        }
-        if (conduitFacts.getRhProd() != null) {
-            rhsmFactMap.put("RH_PROD", conduitFacts.getRhProd());
-        }
-
-        rhsmFactMap.put("SYNC_TIMESTAMP", syncTimestamp);
-
-        FactSet rhsmFacts = new FactSet()
-            .namespace("rhsm")
-            .facts(rhsmFactMap);
-        List<FactSet> facts = new LinkedList<>();
-        facts.add(rhsmFacts);
-
-        CreateHostIn host = new CreateHostIn();
-        host.setAccount(conduitFacts.getAccountNumber());
-        host.setFqdn(conduitFacts.getFqdn());
-        host.setSubscriptionManagerId(conduitFacts.getSubscriptionManagerId());
-        host.setBiosUuid(conduitFacts.getBiosUuid());
-        host.setIpAddresses(conduitFacts.getIpAddresses());
-        host.setMacAddresses(conduitFacts.getMacAddresses());
-        host.facts(facts);
-        return host;
-    }
-
-    public OrgInventory getInventoryForOrgConsumers(List<ConduitFacts> conduitFactsForOrg) {
-        List<ConsumerInventory> hosts = new ArrayList<>(conduitFactsForOrg);
-        return new OrgInventory().consumerInventories(hosts);
-    }
 }

--- a/src/main/java/org/candlepin/insights/inventory/InventoryServiceConfiguration.java
+++ b/src/main/java/org/candlepin/insights/inventory/InventoryServiceConfiguration.java
@@ -115,8 +115,8 @@ public class InventoryServiceConfiguration {
         havingValue = "true")
     public InventoryService kafkaInventoryService(
         @Qualifier("inventoryServiceKafkaProducerTemplate")
-        KafkaTemplate<String, HostOperationMessage> producer, HostsApi hostsApi,
+        KafkaTemplate<String, HostOperationMessage> producer,
         InventoryServiceProperties inventoryServiceProperties) {
-        return new KafkaEnabledInventoryService(inventoryServiceProperties, producer, hostsApi);
+        return new KafkaEnabledInventoryService(inventoryServiceProperties, producer);
     }
 }

--- a/src/main/java/org/candlepin/insights/inventory/InventoryServiceConfiguration.java
+++ b/src/main/java/org/candlepin/insights/inventory/InventoryServiceConfiguration.java
@@ -96,6 +96,9 @@ public class InventoryServiceConfiguration {
     public ProducerFactory<String, HostOperationMessage> inventoryServiceKafkaProducerFactory(
         @Qualifier("inventoryServiceKafkaProperties") KafkaProperties kafkaProperties,
         ObjectMapperContextResolver resolver) {
+        // ObjectMapperContextResolver.getContext is be called with a 'null' object type class
+        // since the resolver is only dealing with a single object type (ObjectMapper) and
+        // therefor the parameter is unused.
         return kafkaConfigurator.defaultProducerFactory(kafkaProperties, resolver.getContext(null));
     }
 

--- a/src/main/java/org/candlepin/insights/inventory/InventoryServiceConfiguration.java
+++ b/src/main/java/org/candlepin/insights/inventory/InventoryServiceConfiguration.java
@@ -1,0 +1,119 @@
+/*
+ * Copyright (c) 2009 - 2019 Red Hat, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ *
+ * Red Hat trademarks are not licensed under GPLv3. No permission is
+ * granted to use or replicate Red Hat trademarks that are incorporated
+ * in this software or its documentation.
+ */
+package org.candlepin.insights.inventory;
+
+import org.candlepin.insights.inventory.client.HostsApiFactory;
+import org.candlepin.insights.inventory.client.InventoryServiceProperties;
+import org.candlepin.insights.inventory.client.resources.HostsApi;
+import org.candlepin.insights.inventory.kafka.HostOperationMessage;
+import org.candlepin.insights.inventory.kafka.InventoryServiceKafkaConfigurator;
+import org.candlepin.insights.inventory.kafka.KafkaEnabledInventoryService;
+import org.candlepin.insights.jackson.ObjectMapperContextResolver;
+
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.beans.factory.annotation.Qualifier;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
+import org.springframework.boot.autoconfigure.kafka.KafkaProperties;
+import org.springframework.boot.context.properties.ConfigurationProperties;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.context.annotation.PropertySource;
+import org.springframework.kafka.annotation.EnableKafka;
+import org.springframework.kafka.core.KafkaTemplate;
+import org.springframework.kafka.core.ProducerFactory;
+
+/**
+ * Configures all beans required to connect to the inventory service's Kafka instance.
+ */
+@EnableKafka
+@Configuration
+@PropertySource("classpath:/rhsm-conduit.properties")
+public class InventoryServiceConfiguration {
+
+    @Autowired(required = false)
+    private InventoryServiceKafkaConfigurator kafkaConfigurator;
+
+    @Bean
+    @ConfigurationProperties(prefix = "rhsm-conduit.inventory-service")
+    public InventoryServiceProperties inventoryServiceProperties() {
+        return new InventoryServiceProperties();
+    }
+
+    @Bean
+    public HostsApiFactory hostsApiFactory(InventoryServiceProperties properties) {
+        return new HostsApiFactory(properties);
+    }
+
+    @Bean
+    @ConditionalOnProperty(prefix = "rhsm-conduit.inventory-service", name = "enableKafka",
+        havingValue = "false", matchIfMissing = true)
+    public InventoryService apiInventoryService(HostsApi hostsApi) {
+        return new DefaultInventoryService(hostsApi);
+    }
+
+    //
+    // KAFKA CONFIGURATION
+    //
+
+    // The default spring-kafka config property namespace is overridden. This allows
+    // separate configuration than that of the kafka instance used by the task queue.
+    @Bean
+    @ConfigurationProperties(prefix = "rhsm-conduit.inventory-service.kafka")
+    @ConditionalOnProperty(prefix = "rhsm-conduit.inventory-service", name = "enableKafka",
+        havingValue = "true")
+    public KafkaProperties inventoryServiceKafkaProperties() {
+        return new KafkaProperties();
+    }
+
+    @Bean
+    @ConditionalOnProperty(prefix = "rhsm-conduit.inventory-service", name = "enableKafka",
+        havingValue = "true")
+    public InventoryServiceKafkaConfigurator inventoryServiceKafkaConfigurator() {
+        return new InventoryServiceKafkaConfigurator();
+    }
+
+    @Bean
+    @ConditionalOnProperty(prefix = "rhsm-conduit.inventory-service", name = "enableKafka",
+        havingValue = "true")
+    public ProducerFactory<String, HostOperationMessage> inventoryServiceKafkaProducerFactory(
+        @Qualifier("inventoryServiceKafkaProperties") KafkaProperties kafkaProperties,
+        ObjectMapperContextResolver resolver) {
+        return kafkaConfigurator.defaultProducerFactory(kafkaProperties, resolver.getContext(null));
+    }
+
+    @Bean
+    @ConditionalOnProperty(prefix = "rhsm-conduit.inventory-service", name = "enableKafka",
+        havingValue = "true")
+    public KafkaTemplate<String, HostOperationMessage> inventoryServiceKafkaProducerTemplate(
+        ProducerFactory<String, HostOperationMessage> factory) {
+        return kafkaConfigurator.taskMessageKafkaTemplate(factory);
+    }
+
+    @Bean
+    @ConditionalOnProperty(prefix = "rhsm-conduit.inventory-service", name = "enableKafka",
+        havingValue = "true")
+    public InventoryService kafkaInventoryService(
+        @Qualifier("inventoryServiceKafkaProducerTemplate")
+        KafkaTemplate<String, HostOperationMessage> producer, HostsApi hostsApi,
+        InventoryServiceProperties inventoryServiceProperties) {
+        return new KafkaEnabledInventoryService(inventoryServiceProperties, producer, hostsApi);
+    }
+}

--- a/src/main/java/org/candlepin/insights/inventory/kafka/CreateUpdateHostMessage.java
+++ b/src/main/java/org/candlepin/insights/inventory/kafka/CreateUpdateHostMessage.java
@@ -18,18 +18,29 @@
  * granted to use or replicate Red Hat trademarks that are incorporated
  * in this software or its documentation.
  */
-package org.candlepin.insights.inventory;
+package org.candlepin.insights.inventory.kafka;
 
-import org.candlepin.insights.api.model.OrgInventory;
+import org.candlepin.insights.inventory.client.model.CreateHostIn;
 
-import java.util.List;
+import java.util.HashMap;
+import java.util.Map;
 
 /**
- * Defines operations against the inventory service.
+ * Represents a message that is sent to the inventory service's kafka instance to request the
+ * creation/update of a host in the inventory service.
  */
-public interface InventoryService {
+public class CreateUpdateHostMessage extends HostOperationMessage<Map<String, String>, CreateHostIn> {
 
-    void sendHostUpdate(List<ConduitFacts> conduitFactsForOrg);
+    public CreateUpdateHostMessage() {
+        this.operation = "add_host";
+        this.metadata = new HashMap<>();
+    }
 
-    OrgInventory getInventoryForOrgConsumers(List<ConduitFacts> conduitFactsForOrg);
+    public CreateUpdateHostMessage(CreateHostIn host) {
+        super("add_host", new HashMap<>(), host);
+    }
+
+    public void setMetadata(String key, String value) {
+        this.metadata.put(key, value);
+    }
 }

--- a/src/main/java/org/candlepin/insights/inventory/kafka/HostOperationMessage.java
+++ b/src/main/java/org/candlepin/insights/inventory/kafka/HostOperationMessage.java
@@ -1,0 +1,78 @@
+/*
+ * Copyright (c) 2009 - 2019 Red Hat, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ *
+ * Red Hat trademarks are not licensed under GPLv3. No permission is
+ * granted to use or replicate Red Hat trademarks that are incorporated
+ * in this software or its documentation.
+ */
+package org.candlepin.insights.inventory.kafka;
+
+/**
+ * Represents the kafka message that should be sent to the inventory service. Each message
+ * should include an operation, a metadata object and a data object that will be converted
+ * to JSON when sent.
+ *
+ * The inventory service's message consumer is expecting a JSON message in the following format:
+ * <pre>
+ *    {
+ *      "operation": $SUPPORTED_OPERATION,
+ *      "metadata": $M_AS_JSON_STRING,
+ *      "data": $D_AS_JSON_STRING
+ *    }
+ * </pre>
+ *
+ * @param <M> the type of the metadata object to be included in the JSON message.
+ * @param <D> the type of the data object to be included in the JSON message.
+ */
+public abstract class HostOperationMessage<M, D> {
+
+    protected String operation;
+    protected M metadata;
+    protected D data;
+
+    public HostOperationMessage() {
+    }
+
+    public HostOperationMessage(String operation, M metadata, D data) {
+        this.operation = operation;
+        this.metadata = metadata;
+        this.data = data;
+    }
+
+    public String getOperation() {
+        return operation;
+    }
+
+    public void setOperation(String operation) {
+        this.operation = operation;
+    }
+
+    public M getMetadata() {
+        return metadata;
+    }
+
+    public void setMetadata(M metadata) {
+        this.metadata = metadata;
+    }
+
+    public D getData() {
+        return data;
+    }
+
+    public void setData(D data) {
+        this.data = data;
+    }
+}

--- a/src/main/java/org/candlepin/insights/inventory/kafka/InventoryServiceKafkaConfigurator.java
+++ b/src/main/java/org/candlepin/insights/inventory/kafka/InventoryServiceKafkaConfigurator.java
@@ -1,0 +1,60 @@
+/*
+ * Copyright (c) 2009 - 2019 Red Hat, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ *
+ * Red Hat trademarks are not licensed under GPLv3. No permission is
+ * granted to use or replicate Red Hat trademarks that are incorporated
+ * in this software or its documentation.
+ */
+package org.candlepin.insights.inventory.kafka;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+
+import org.apache.kafka.clients.producer.ProducerConfig;
+import org.apache.kafka.common.serialization.StringSerializer;
+import org.springframework.boot.autoconfigure.kafka.KafkaProperties;
+import org.springframework.kafka.core.DefaultKafkaProducerFactory;
+import org.springframework.kafka.core.KafkaTemplate;
+import org.springframework.kafka.core.ProducerFactory;
+import org.springframework.kafka.support.serializer.JsonSerializer;
+
+import java.util.Map;
+
+/**
+ * Encapsulates the creation of all components required for producing Kafka
+ * messages for the inventory service.
+ */
+public class InventoryServiceKafkaConfigurator {
+
+    public DefaultKafkaProducerFactory<String, HostOperationMessage> defaultProducerFactory(
+        KafkaProperties kafkaProperties, ObjectMapper mapper) {
+        Map<String, Object> producerConfig = kafkaProperties.buildProducerProperties();
+        producerConfig.put(ProducerConfig.KEY_SERIALIZER_CLASS_CONFIG, StringSerializer.class);
+
+        DefaultKafkaProducerFactory<String, HostOperationMessage> factory =
+            new DefaultKafkaProducerFactory<>(producerConfig);
+        // Because inventory requires us to not sent JSON fields that have null values,
+        // we need to customize the ObjectMapper used by spring-kafka. There is no way to customize
+        // it via configuration properties, so we use the custom one that is configured for the
+        // application that is created via the ApplicationConfiguration.
+        factory.setValueSerializer(new JsonSerializer<>(mapper));
+        return factory;
+    }
+
+    public KafkaTemplate<String, HostOperationMessage> taskMessageKafkaTemplate(
+        ProducerFactory<String, HostOperationMessage> factory) {
+        return new KafkaTemplate<>(factory);
+    }
+}

--- a/src/main/java/org/candlepin/insights/inventory/kafka/KafkaEnabledInventoryService.java
+++ b/src/main/java/org/candlepin/insights/inventory/kafka/KafkaEnabledInventoryService.java
@@ -21,9 +21,8 @@
 package org.candlepin.insights.inventory.kafka;
 
 import org.candlepin.insights.inventory.ConduitFacts;
-import org.candlepin.insights.inventory.DefaultInventoryService;
+import org.candlepin.insights.inventory.InventoryService;
 import org.candlepin.insights.inventory.client.InventoryServiceProperties;
-import org.candlepin.insights.inventory.client.resources.HostsApi;
 
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -36,7 +35,7 @@ import java.util.List;
  * An InventoryService implementation that includes a Kafka producer that is capable
  * of sending messages to the inventory service's Kafka instance.
  */
-public class KafkaEnabledInventoryService extends DefaultInventoryService {
+public class KafkaEnabledInventoryService extends InventoryService {
 
     private static final Logger log = LoggerFactory.getLogger(KafkaEnabledInventoryService.class);
 
@@ -44,8 +43,7 @@ public class KafkaEnabledInventoryService extends DefaultInventoryService {
     private final String hostIngressTopic;
 
     public KafkaEnabledInventoryService(InventoryServiceProperties inventoryServiceProperties,
-        KafkaTemplate<String, HostOperationMessage> producer, HostsApi hostsInventoryApi) {
-        super(hostsInventoryApi);
+        KafkaTemplate<String, HostOperationMessage> producer) {
         this.producer = producer;
         this.hostIngressTopic = inventoryServiceProperties.getKafkaHostIngressTopic();
     }

--- a/src/main/java/org/candlepin/insights/inventory/kafka/KafkaEnabledInventoryService.java
+++ b/src/main/java/org/candlepin/insights/inventory/kafka/KafkaEnabledInventoryService.java
@@ -1,0 +1,77 @@
+/*
+ * Copyright (c) 2009 - 2019 Red Hat, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ *
+ * Red Hat trademarks are not licensed under GPLv3. No permission is
+ * granted to use or replicate Red Hat trademarks that are incorporated
+ * in this software or its documentation.
+ */
+package org.candlepin.insights.inventory.kafka;
+
+import org.candlepin.insights.inventory.ConduitFacts;
+import org.candlepin.insights.inventory.DefaultInventoryService;
+import org.candlepin.insights.inventory.client.InventoryServiceProperties;
+import org.candlepin.insights.inventory.client.resources.HostsApi;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.kafka.core.KafkaTemplate;
+
+import java.time.OffsetDateTime;
+import java.util.List;
+
+/**
+ * An InventoryService implementation that includes a Kafka producer that is capable
+ * of sending messages to the inventory service's Kafka instance.
+ */
+public class KafkaEnabledInventoryService extends DefaultInventoryService {
+
+    private static final Logger log = LoggerFactory.getLogger(KafkaEnabledInventoryService.class);
+
+    private final KafkaTemplate<String, HostOperationMessage> producer;
+    private final String hostIngressTopic;
+
+    public KafkaEnabledInventoryService(InventoryServiceProperties inventoryServiceProperties,
+        KafkaTemplate<String, HostOperationMessage> producer, HostsApi hostsInventoryApi) {
+        super(hostsInventoryApi);
+        this.producer = producer;
+        this.hostIngressTopic = inventoryServiceProperties.getKafkaHostIngressTopic();
+    }
+
+    @Override
+    public void sendHostUpdate(List<ConduitFacts> facts) {
+        if (facts.isEmpty()) {
+            log.info("No facts to report!");
+            return;
+        }
+
+        OffsetDateTime now = OffsetDateTime.now();
+        for (ConduitFacts factSet : facts) {
+            log.debug("Sending: {}:{}:{}", factSet.getAccountNumber(), factSet.getOrgId(),
+                factSet.getSubscriptionManagerId());
+
+            // Attempt to send the host create/update message. If the send fails for any reason,
+            // log the error and move on to the next one.
+            try {
+                producer.send(hostIngressTopic, new CreateUpdateHostMessage(createHost(factSet, now)));
+            }
+            catch (Exception e) {
+                log.error("Unable to send host create/update message.", e);
+            }
+        }
+
+    }
+
+}

--- a/src/main/java/org/candlepin/insights/jackson/ObjectMapperContextResolver.java
+++ b/src/main/java/org/candlepin/insights/jackson/ObjectMapperContextResolver.java
@@ -37,7 +37,10 @@ import javax.ws.rs.ext.Provider;
  * ObjectMapper instance. This is marked as a Provider so that RestEasy will
  * use the configured ObjectMapper provided by this instance.
  *
- * NOTE: this class is responsible for the server's serialization/deserialization only.
+ * The ObjectMapper created by this class can be considered an application shared 'default' instance.
+ * It is currently used by the application's API JSON (de)serialization, as well as the inventory
+ * service's Kafka producer.
+ *
  * Configuration of the ObjectMapper used in the clients is mostly done in the ApiClient classes, and we can
  * customize them via <pre>apiClient.getJSON().getContext(ObjectMapper.class)</pre> (see
  * {@link org.candlepin.insights.inventory.client.HostsApiFactory} for an example).

--- a/src/main/java/org/candlepin/insights/task/queue/kafka/KafkaConfigurator.java
+++ b/src/main/java/org/candlepin/insights/task/queue/kafka/KafkaConfigurator.java
@@ -46,7 +46,7 @@ import java.util.Map;
 
 /**
  * Encapsulates the creation of all components required for producing and consuming Kafka
- * messages.
+ * messages for the kafka task queue.
  */
 public class KafkaConfigurator {
 

--- a/src/main/resources/rhsm-conduit.properties
+++ b/src/main/resources/rhsm-conduit.properties
@@ -17,6 +17,10 @@ rhsm-conduit.org-sync.fileBasedOrgListStrategy.org-resource-location=classpath:e
 # The API key configured by the inventory service.
 rhsm-conduit.inventory-service.apiKey=changeit
 
+# Inventory service kafka configuration
+#rhsm-conduit.inventory-service.enableKafka=true
+#rhsm-conduit.inventory-service.kafka.bootstrap-servers=localhost:9092
+
 # Default Quartz datasource.  Override by pulling in another rhsm-conduit.properties file via an
 # -Dspring.config.additional-location argument
 rhsm-conduit.datasource.platform=hsqldb

--- a/src/test/java/org/candlepin/insights/controller/InventoryControllerTest.java
+++ b/src/test/java/org/candlepin/insights/controller/InventoryControllerTest.java
@@ -26,7 +26,6 @@ import static org.mockito.BDDMockito.*;
 
 import org.candlepin.insights.inventory.ConduitFacts;
 import org.candlepin.insights.inventory.InventoryService;
-import org.candlepin.insights.inventory.client.model.BulkHostOut;
 import org.candlepin.insights.orgsync.OrgListStrategy;
 import org.candlepin.insights.pinhead.PinheadService;
 import org.candlepin.insights.pinhead.client.model.Consumer;
@@ -72,7 +71,6 @@ public class InventoryControllerTest {
         consumer2.setAccountNumber("account");
         when(pinheadService.getOrganizationConsumers("123")).thenReturn(
             Arrays.asList(consumer1, consumer2));
-        when(inventoryService.sendHostUpdate(isNotNull())).thenReturn(new BulkHostOut());
         controller.updateInventoryForOrg("123");
         Mockito.verify(inventoryService, times(1)).sendHostUpdate(any());
     }
@@ -107,7 +105,6 @@ public class InventoryControllerTest {
         consumer2.setUuid(uuid2.toString());
         when(pinheadService.getOrganizationConsumers("123")).thenReturn(
             Arrays.asList(consumer1, consumer2));
-        when(inventoryService.sendHostUpdate(isNotNull())).thenReturn(new BulkHostOut());
         controller.updateInventoryForOrg("123");
         Mockito.verify(inventoryService, times(1)).sendHostUpdate(any());
     }

--- a/src/test/java/org/candlepin/insights/inventory/DefaultInventoryServiceTest.java
+++ b/src/test/java/org/candlepin/insights/inventory/DefaultInventoryServiceTest.java
@@ -41,7 +41,7 @@ import java.util.List;
 import java.util.Map;
 
 @ExtendWith(MockitoExtension.class)
-public class InventoryServiceTest {
+public class DefaultInventoryServiceTest {
     @Mock
     HostsApi api;
 
@@ -66,7 +66,7 @@ public class InventoryServiceTest {
 
     @Test
     public void testSendHostUpdatePopulatesAllFieldsWithFullConduitFactsRecord() throws ApiException {
-        InventoryService inventoryService = new InventoryService(api);
+        DefaultInventoryService inventoryService = new DefaultInventoryService(api);
         inventoryService.sendHostUpdate(Collections.singletonList(createFullyPopulatedConduitFacts()));
         Map<String, Object> expectedFactMap = new HashMap<>();
         expectedFactMap.put("CPU_SOCKETS", 4);
@@ -118,7 +118,7 @@ public class InventoryServiceTest {
 
     @Test
     public void testGetInventoryForOrgConsumersContainsEquivalentConsumerInventory() {
-        InventoryService inventoryService = new InventoryService(null);
+        DefaultInventoryService inventoryService = new DefaultInventoryService(null);
         ConduitFacts conduitFacts = createFullyPopulatedConduitFacts();
         OrgInventory orgInventory = inventoryService
             .getInventoryForOrgConsumers(Collections.singletonList(conduitFacts));

--- a/src/test/java/org/candlepin/insights/inventory/kafka/KafkaEnabledInventoryServiceTest.java
+++ b/src/test/java/org/candlepin/insights/inventory/kafka/KafkaEnabledInventoryServiceTest.java
@@ -28,7 +28,6 @@ import static org.mockito.Mockito.when;
 import org.candlepin.insights.inventory.ConduitFacts;
 import org.candlepin.insights.inventory.client.InventoryServiceProperties;
 import org.candlepin.insights.inventory.client.model.FactSet;
-import org.candlepin.insights.inventory.client.resources.HostsApi;
 
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -45,9 +44,6 @@ public class KafkaEnabledInventoryServiceTest {
 
     @Mock
     private KafkaTemplate producer;
-
-    @Mock
-    private HostsApi api;
 
     @Test
     public void ensureKafkaProducerSendsHostMessage() {
@@ -66,7 +62,7 @@ public class KafkaEnabledInventoryServiceTest {
         expectedFacts.setCpuSockets(45);
 
         InventoryServiceProperties props = new InventoryServiceProperties();
-        KafkaEnabledInventoryService service = new KafkaEnabledInventoryService(props, producer, api);
+        KafkaEnabledInventoryService service = new KafkaEnabledInventoryService(props, producer);
         service.sendHostUpdate(Arrays.asList(expectedFacts));
 
         assertEquals(props.getKafkaHostIngressTopic(), topicCaptor.getValue());
@@ -86,16 +82,14 @@ public class KafkaEnabledInventoryServiceTest {
         assertEquals(expectedFacts.getOrgId(), (String) rhsmFacts.get("orgId"));
         assertEquals(expectedFacts.getCpuCores(), (Integer) rhsmFacts.get("CPU_CORES"));
         assertEquals(expectedFacts.getCpuSockets(), (Integer) rhsmFacts.get("CPU_SOCKETS"));
-
-        verifyZeroInteractions(api);
     }
 
     @Test
     public void ensureNoMessageWithEmptyFactList() {
         InventoryServiceProperties props = new InventoryServiceProperties();
-        KafkaEnabledInventoryService service = new KafkaEnabledInventoryService(props, producer, api);
+        KafkaEnabledInventoryService service = new KafkaEnabledInventoryService(props, producer);
         service.sendHostUpdate(Arrays.asList());
 
-        verifyZeroInteractions(producer, api);
+        verifyZeroInteractions(producer);
     }
 }

--- a/src/test/java/org/candlepin/insights/inventory/kafka/KafkaEnabledInventoryServiceTest.java
+++ b/src/test/java/org/candlepin/insights/inventory/kafka/KafkaEnabledInventoryServiceTest.java
@@ -1,0 +1,101 @@
+/*
+ * Copyright (c) 2009 - 2019 Red Hat, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ *
+ * Red Hat trademarks are not licensed under GPLv3. No permission is
+ * granted to use or replicate Red Hat trademarks that are incorporated
+ * in this software or its documentation.
+ */
+package org.candlepin.insights.inventory.kafka;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.mockito.Mockito.verifyZeroInteractions;
+import static org.mockito.Mockito.when;
+
+import org.candlepin.insights.inventory.ConduitFacts;
+import org.candlepin.insights.inventory.client.InventoryServiceProperties;
+import org.candlepin.insights.inventory.client.model.FactSet;
+import org.candlepin.insights.inventory.client.resources.HostsApi;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.kafka.core.KafkaTemplate;
+
+import java.util.Arrays;
+import java.util.Map;
+
+@ExtendWith(MockitoExtension.class)
+public class KafkaEnabledInventoryServiceTest {
+
+    @Mock
+    private KafkaTemplate producer;
+
+    @Mock
+    private HostsApi api;
+
+    @Test
+    public void ensureKafkaProducerSendsHostMessage() {
+
+        ArgumentCaptor<String> topicCaptor = ArgumentCaptor.forClass(String.class);
+        ArgumentCaptor<CreateUpdateHostMessage> messageCaptor =
+            ArgumentCaptor.forClass(CreateUpdateHostMessage.class);
+
+        when(producer.send(topicCaptor.capture(), messageCaptor.capture())).thenReturn(null);
+
+        ConduitFacts expectedFacts = new ConduitFacts();
+        expectedFacts.setFqdn("my_fqdn");
+        expectedFacts.setAccountNumber("my_account");
+        expectedFacts.setOrgId("my_org");
+        expectedFacts.setCpuCores(25);
+        expectedFacts.setCpuSockets(45);
+
+        InventoryServiceProperties props = new InventoryServiceProperties();
+        KafkaEnabledInventoryService service = new KafkaEnabledInventoryService(props, producer, api);
+        service.sendHostUpdate(Arrays.asList(expectedFacts));
+
+        assertEquals(props.getKafkaHostIngressTopic(), topicCaptor.getValue());
+
+        CreateUpdateHostMessage message = messageCaptor.getValue();
+        assertNotNull(message);
+        assertEquals("add_host", message.getOperation());
+        assertEquals(expectedFacts.getAccountNumber(), message.getData().getAccount());
+        assertEquals(expectedFacts.getFqdn(), message.getData().getFqdn());
+
+        assertNotNull(message.getData().getFacts());
+        assertEquals(1, message.getData().getFacts().size());
+        FactSet rhsm = message.getData().getFacts().get(0);
+        assertEquals("rhsm", rhsm.getNamespace());
+
+        Map<String, Object> rhsmFacts = (Map<String, Object>) rhsm.getFacts();
+        assertEquals(expectedFacts.getOrgId(), (String) rhsmFacts.get("orgId"));
+        assertEquals(expectedFacts.getCpuCores(), (Integer) rhsmFacts.get("CPU_CORES"));
+        assertEquals(expectedFacts.getCpuSockets(), (Integer) rhsmFacts.get("CPU_SOCKETS"));
+
+        verifyZeroInteractions(api);
+    }
+
+    @Test
+    public void ensureNoMessageWithEmptyFactList() {
+        InventoryServiceProperties props = new InventoryServiceProperties();
+        KafkaEnabledInventoryService service = new KafkaEnabledInventoryService(props, producer, api);
+        service.sendHostUpdate(Arrays.asList());
+
+        verifyZeroInteractions(producer, api);
+    }
+}


### PR DESCRIPTION
Pulled out inventory service into an interface and created an
implementation that only uses the HTTP client, and another that
enables Kafka messaging to send inventory host create/update
requests.

To enable use of the kafka service for sending host data, the
following configuration properties should be set:
  rhsm-conduit.inventory-service.enableKafka=true
  rhsm-conduit.inventory-service.kafka.bootstrap-servers=your_kafka:9092

NOTE: Additional kafka specific properties can be set via the following
property namespace:
  rhsm-conduit.inventory-service.kafka.*

## Testing
As of right now, insights-inventory does not have the kafka code merged to master. To test this code, you will need to use the following branch:
   **origin/split_inventory_service**

They are using docker to set up the service so I followed suit. If we need to later on, we should put a little more time into seeing how we can integrate our deployment of inventory with what they currently have. One thing I like about our route is that we get the kafka GUI installed when we install our own kafka instance.

From the inventory checkout root:
1. Start a kafka and DB instance (unless you reconfigure the scripts you will need to stop your local postgres instance)
```bash
$ docker-compose -f dev.yml up
```
2. Add a host entry pointing to the kafka instance that is running on localhost:
```
127.0.0.1      kafka
```
3. Run the kafka host message listener service:
```bash
$ make run_inv_mq_service
```
4. Run the inventory web service
```bash
$ make run_inv_web_service
```
5. Add the following to the rhsm-conduit configuration file. **Note: You still need to configure the API url and key for the inventory service since we are still using that endpoint to fetch data from our API endpoint.**
```
rhsm-conduit.inventory-service.enableKafka=true
rhsm-conduit.inventory-service.kafka.bootstrap-servers=kafka:29092
```
6. Start up conduit as per normal means.