### PR TITLE
Set communication with pinhead service to retry on failure

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -155,6 +155,7 @@ dependencies {
     }
 
     compile "org.springframework.boot:spring-boot-starter-actuator"
+    compile "org.springframework.boot:spring-boot-starter-aop"
     compile "org.springframework.boot:spring-boot-starter-web"
     compile "org.springframework.boot:spring-boot-starter-jdbc"
     compile "org.springframework.boot:spring-boot-starter-quartz"

--- a/src/main/java/org/candlepin/insights/task/queue/kafka/KafkaTaskQueueConfiguration.java
+++ b/src/main/java/org/candlepin/insights/task/queue/kafka/KafkaTaskQueueConfiguration.java
@@ -38,7 +38,6 @@ import org.springframework.kafka.core.KafkaTemplate;
 import org.springframework.kafka.core.ProducerFactory;
 import org.springframework.kafka.listener.ConcurrentMessageListenerContainer;
 
-
 /**
  * A spring configuration that configures the required Beans to set up a KafkaTaskQueue.
  *
@@ -125,5 +124,4 @@ public class KafkaTaskQueueConfiguration {
     public KafkaTaskProcessor taskProcessor(TaskFactory taskFactory) {
         return new KafkaTaskProcessor(taskFactory);
     }
-
 }


### PR DESCRIPTION
Using the Spring Retry project we can avail ourselves of some
standardized classes to implement a retry policy if communication with
pinhead fails.

---
# Testing 
1. Set up a dummy HTTP response to mimic Pinhead and always return an error.  Drop the following in a file called `404.response`:
```
HTTP/1.0 404 File not found
Server: PoorMansHTTP
Date: Thu, 08 Aug 2019 17:25:31 GMT
Content-type: text/html
Content-Length: 65
Last-Modified: Thu, 08 Aug 2019 17:21:30 GMT

<html>

<body>
  <h1>ALB all origins down</h1>
</body>

</html> 
```
2. Install  `nc` if you haven't already.  Start it up with TLS support as a poor man's HTTP server that will always respond the same way.
```
$ nc -klv -p 9180 -e '/bin/cat 404.response' --ssl --ssl-cert pinhead-client/src/test/resources/server.crt --ssl-key  pinhead-client/src/test/resources/server.key
```
3. Run a Kafka instance as described in the Kafka README.
4. Enable Kafka in the `rhsm-conduit.properties` file:
```
rhsm-conduit.tasks.queue=kafka
rhsm-conduit.tasks.task-group=rhsm-conduit-tasks
spring.kafka.listener.concurrency=1
spring.kafka.bootstrap-servers=localhost:9092
```
5. Edit `empty-org-list.txt` as follows
```
Account Number,Candlepin Org ID                                                                                                      
1234,5678
```
6. Run the app
```
$ ./gradlew bootRun --args="--server.port=9166 --rhsm-conduit.pinhead.url=https://localhost:9180/zap --rhsm-conduit.pinhead.keystore-file=pinhead-client/src/test/resources/client.jks --rhsm-conduit.pinhead.keystore-password=password --rhsm-conduit.pinhead.truststore-file=pinhead-client/src/test/resources/server.jks --rhsm-conduit.pinhead.truststore-password=password --rhsm-conduit.org-sync.schedule='*/20 * * * * ?' --logging.level.org.springframework.retry=DEBUG --logging.level.org.springframework.kafka=DEBUG"
```
The command above will instruct the org sync job to send a message to Kafka every 20 seconds.  The message will get picked up, contact our phoney HTTP server, and then fail.  With the new code, you will see output similar to

```
2019-08-12 15:10:20,506 [thread=rhsm-conduit-task-processor-0-C-1] [=, org=, csid=] DEBUG org.springframework.retry.support.RetryTemplate - Retry: count=0                                                                                                                  
2019-08-12 15:10:20,546 [thread=rhsm-conduit-task-processor-0-C-1] [=, org=, csid=] DEBUG org.springframework.retry.backoff.ExponentialRandomBackOffPolicy - Sleeping for 1712                                                                                              
2019-08-12 15:10:22,258 [thread=rhsm-conduit-task-processor-0-C-1] [=, org=, csid=] DEBUG org.springframework.retry.support.RetryTemplate - Checking for rethrow: count=1                                                                                                   
2019-08-12 15:10:22,258 [thread=rhsm-conduit-task-processor-0-C-1] [=, org=, csid=] DEBUG org.springframework.retry.support.RetryTemplate - Retry: count=1                                                                                                                  
```
---
# Notes
Currently the back-off is configured to use a random exponential algorithm and try a maximum of 4 times.  The initial wait is 1 second.  So the algorithm should follow the following sequence, wait 1 second, wait between 1 and 2 seconds, wait between 2 and 4 seconds, wait between 4 and 8 seconds.  I elected for a random approach so that nodes don't end up getting synchronized and then all rush to the service at once for a retry.