### PR TITLE
Add cloudwatch appender

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -36,6 +36,7 @@ ext {
     commons_csv_version = "1.6"
     kafka_avro_serializer_version = "5.2.1"
     avro_version = "1.8.2"
+    aws_sdk_version = "1.11.32"
 }
 
 allprojects {
@@ -78,6 +79,9 @@ allprojects {
             dependency "org.hamcrest:hamcrest:$hamcrest_version"
             dependency "org.postgresql:postgresql:$postgres_jdbc_driver_version"
             dependency "org.jboss.resteasy:resteasy-spring-boot-starter:$resteasy_spring_boot_starter_version"
+            dependency "com.j256.cloudwatchlogbackappender:cloudwatchlogbackappender:1.11"
+            dependency "com.amazonaws:aws-java-sdk-logs:$aws_sdk_version"
+            dependency "com.amazonaws:aws-java-sdk-ec2:$aws_sdk_version"
             dependencySet(group: "org.jboss.resteasy", version: "$resteasy_version") {
                 entry "resteasy-client"
                 entry "resteasy-multipart-provider"
@@ -174,6 +178,7 @@ dependencies {
     runtime("org.jboss.resteasy:resteasy-validator-provider-11") {
         exclude group: 'org.hibernate' // exclude older hibernate validator
     }
+    runtime "com.j256.cloudwatchlogbackappender:cloudwatchlogbackappender"
 }
 
 compileJava.dependsOn(processResources)

--- a/src/main/java/org/candlepin/insights/logging/CloudWatchEmergencyFilter.java
+++ b/src/main/java/org/candlepin/insights/logging/CloudWatchEmergencyFilter.java
@@ -1,0 +1,46 @@
+/*
+ * Copyright (c) 2009 - 2019 Red Hat, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ *
+ * Red Hat trademarks are not licensed under GPLv3. No permission is
+ * granted to use or replicate Red Hat trademarks that are incorporated
+ * in this software or its documentation.
+ */
+package org.candlepin.insights.logging;
+
+import ch.qos.logback.classic.spi.ILoggingEvent;
+import ch.qos.logback.core.filter.Filter;
+import ch.qos.logback.core.spi.FilterReply;
+
+/**
+ * Filter that is used to show only com.j256.cloudwatchlogbackappender.CloudWatchAppender messages.
+ *
+ * CloudWatchAppender writes *all* messages to its emergency appender if it encounters a problem, but
+ * we only want to see messages that tell us that CloudWatchAppender is not functioning, as we'll write
+ * logs to ConsoleAppender already.
+ *
+ * This filter allows us to write all log messages to both CloudWatch and the console, without unnecessary
+ * repetitions.
+ */
+public class CloudWatchEmergencyFilter extends Filter<ILoggingEvent> {
+
+    @Override
+    public FilterReply decide(ILoggingEvent event) {
+        if (event.getLoggerName().equals("com.j256.cloudwatchlogbackappender.CloudWatchAppender")) {
+            return FilterReply.ACCEPT;
+        }
+        return FilterReply.DENY;
+    }
+}

--- a/src/main/resources/logback-spring.xml
+++ b/src/main/resources/logback-spring.xml
@@ -15,6 +15,21 @@
         </encoder>
     </appender>
 
+    <appender name="EmergencyAppender" class="ch.qos.logback.core.ConsoleAppender">
+        <filter class="org.candlepin.insights.logging.CloudWatchEmergencyFilter" />
+        <encoder>
+            <pattern>%d{ISO8601} [thread=%thread] [%X{requestType}=%X{requestUuid}, org=%X{org}, csid=%X{csid}] %-5p %c - %m%n</pattern>
+        </encoder>
+    </appender>
+
+    <appender name="CloudWatchAppender" class="com.j256.cloudwatchlogbackappender.CloudWatchAppender">
+        <region>${AWS_REGION}</region>
+        <logGroup>platform</logGroup>
+        <logStream>namespace</logStream>
+        <layout class="net.logstash.logback.layout.LogstashLayout" />
+        <appender-ref ref="EmergencyAppender" />
+    </appender>
+
     <appender name="ErrorAppender" class="ch.qos.logback.core.FileAppender">
         <file>/var/log/rhsm-conduit/error.log</file>
         <encoder>
@@ -32,5 +47,6 @@
         <appender-ref ref="ConsoleAppender" />
         <!--<appender-ref ref="RhsmConduitAppender" />-->
         <!--<appender-ref ref="ErrorAppender" />-->
+        <!--<appender-ref ref="CloudWatchAppender" />-->
     </root>
 </configuration>


### PR DESCRIPTION
Testing
-------
I was able to test by setting a few environment variables namely:
```
export AWS_REGION=eu-west-2
export AWS_ACCESS_KEY_ID=key_id
export AWS_SECRET_ACCESS_KEY=key
```
and then adding a hosts entry:
```
127.0.0.1 logs.eu-west-2.amazonaws.com
```
and then running nc as follows:
```
sudo nc -klv -p 443 --ssl --ssl-cert pinhead-client/src/test/resources/server.crt --ssl-key  pinhead-client/src/test/resources/server.key
```
and then running the app with `-Dcom.amazonaws.sdk.disableCertChecking`; You can see the requests the appender attempts to make to cloudwatch, and after some retries/timeouts you'll eventually see the actual JSON messages.