### PR TITLE
ENT1543: ignore IP address entries labeled with 'Unknown'

### DIFF
--- a/src/main/java/org/candlepin/insights/controller/InventoryController.java
+++ b/src/main/java/org/candlepin/insights/controller/InventoryController.java
@@ -74,6 +74,8 @@ public class InventoryController {
     public static final String MEMORY_MEMTOTAL = "memory.memtotal";
     public static final String UNAME_MACHINE = "uname.machine";
     public static final String VIRT_IS_GUEST = "virt.is_guest";
+    public static final String UNKNOWN = "unknown";
+    public static final String TRUE = "True";
 
     @Autowired
     private InventoryService inventoryService;
@@ -173,7 +175,13 @@ public class InventoryController {
         Set<String> ipAddresses = new HashSet<>();
         pinheadFacts.entrySet().stream()
             .filter(entry -> entry.getKey().matches(IP_ADDRESS_FACT_REGEX) && !isEmpty(entry.getValue()))
-            .forEach(entry -> ipAddresses.addAll(Arrays.asList(entry.getValue().split(COMMA_REGEX))));
+            .forEach(entry -> {
+                List<String> items = Arrays.asList(entry.getValue().split(COMMA_REGEX));
+                ipAddresses.addAll(items.stream()
+                    .filter(addr -> !isEmpty(addr) && !addr.equalsIgnoreCase(UNKNOWN))
+                    .collect(Collectors.toList())
+                );
+            });
 
         if (!ipAddresses.isEmpty()) {
             facts.setIpAddresses(new ArrayList(ipAddresses));
@@ -185,8 +193,8 @@ public class InventoryController {
         ConduitFacts facts) {
 
         String isGuest = pinheadFacts.get(VIRT_IS_GUEST);
-        if (!isEmpty(isGuest) && !isGuest.equalsIgnoreCase("Unknown")) {
-            facts.setIsVirtual(isGuest.equalsIgnoreCase("True"));
+        if (!isEmpty(isGuest) && !isGuest.equalsIgnoreCase(UNKNOWN)) {
+            facts.setIsVirtual(isGuest.equalsIgnoreCase(TRUE));
         }
 
         String vmHost = consumer.getHypervisorName();

--- a/src/test/java/org/candlepin/insights/controller/InventoryControllerTest.java
+++ b/src/test/java/org/candlepin/insights/controller/InventoryControllerTest.java
@@ -238,6 +238,24 @@ public class InventoryControllerTest {
         assertEquals(5, conduitFacts.getIpAddresses().size());
     }
 
+    @Test
+    public void testUnknownIpsAreIgnored() {
+        Map<String, String> pinheadFacts = new HashMap<String, String>();
+        pinheadFacts.put("net.interface.eth0.ipv4_address", "192.168.1.1");
+        pinheadFacts.put("net.interface.lo.ipv4_address", "127.0.0.1");
+        pinheadFacts.put("net.interface.eth0.ipv6_address.link", "fe80::2323:912a:177a:d8e6");
+        pinheadFacts.put("net.interface.virbr0-nic.ipv4_address", "Unknown");
+        pinheadFacts.put("net.interface.virbr0.ipv4_address", "192.168.122.1");
+        pinheadFacts.put("net.interface.wlan0.ipv4_address", "Unknown");
+
+        ConduitFacts conduitFacts = new ConduitFacts();
+        controller.extractIpAddresses(pinheadFacts, conduitFacts);
+
+        assertContainSameElements(
+            Arrays.asList("192.168.1.1", "127.0.0.1", "fe80::2323:912a:177a:d8e6", "192.168.122.1"),
+            conduitFacts.getIpAddresses());
+    }
+
     private void assertContainSameElements(List<String> list1, List<String> list2) {
         Collections.sort(list1);
         Collections.sort(list2);


### PR DESCRIPTION
Ensure that hosts with some IP addresses labelled with 'Unknown' will not be exempt from the org sync.