### PR TITLE
Add Timed annotations to core function calls.

### DIFF
--- a/src/main/java/org/candlepin/insights/ApplicationConfiguration.java
+++ b/src/main/java/org/candlepin/insights/ApplicationConfiguration.java
@@ -36,6 +36,7 @@ import org.springframework.boot.jdbc.DataSourceBuilder;
 import org.springframework.boot.web.servlet.ServletContextInitializer;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.context.annotation.EnableAspectJAutoProxy;
 import org.springframework.context.annotation.Import;
 import org.springframework.context.annotation.Primary;
 import org.springframework.context.annotation.PropertySource;
@@ -49,6 +50,9 @@ import org.springframework.web.servlet.config.annotation.ResourceHandlerRegistry
 import org.springframework.web.servlet.config.annotation.ViewControllerRegistry;
 import org.springframework.web.servlet.config.annotation.WebMvcConfigurer;
 
+import io.micrometer.core.aop.TimedAspect;
+import io.micrometer.core.instrument.MeterRegistry;
+
 import java.util.Properties;
 
 import javax.servlet.ServletContext;
@@ -59,6 +63,7 @@ import javax.validation.Validator;
 /** Class to hold configuration beans */
 @Configuration
 @EnableRetry
+@EnableAspectJAutoProxy
 @Import(ResteasyAutoConfiguration.class) // needed to be able to reference ResteasyApplicationBuilder
 @EnableConfigurationProperties(ApplicationProperties.class)
 // The values in application.yaml should already be loaded by default
@@ -68,8 +73,7 @@ public class ApplicationConfiguration implements WebMvcConfigurer {
     @Autowired
     private ApplicationProperties applicationProperties;
 
-
-     /**
+    /**
      * Used to set context-param values since Spring Boot does not have a web.xml.  Technically
      * context-params can be set in application.properties (or application.yaml) with the prefix
      * "server.servlet.context-parameters" but the Spring Boot documentation kind of hides that
@@ -184,6 +188,10 @@ public class ApplicationConfiguration implements WebMvcConfigurer {
         return retryTemplate;
     }
 
+    @Bean
+    public TimedAspect timedAspect(MeterRegistry registry) {
+        return new TimedAspect(registry);
+    }
 
     @Override
     public void addViewControllers(ViewControllerRegistry registry) {

--- a/src/main/java/org/candlepin/insights/resource/InventoriesResource.java
+++ b/src/main/java/org/candlepin/insights/resource/InventoriesResource.java
@@ -28,6 +28,7 @@ import org.candlepin.insights.task.TaskManager;
 import org.springframework.stereotype.Component;
 import org.springframework.validation.annotation.Validated;
 
+import io.micrometer.core.annotation.Timed;
 
 /**
  * The inventories API implementation.
@@ -45,11 +46,13 @@ public class InventoriesResource implements InventoriesApi {
     }
 
     @Override
+    @Timed("rhsm-conduit.get.inventory")
     public OrgInventory getInventoryForOrg(String orgId) {
         return inventoryController.getInventoryForOrg(orgId);
     }
 
     @Override
+    @Timed("rhsm-conduit.update.inventory")
     public void updateInventoryForOrg(String orgId) {
         tasks.updateOrgInventory(orgId);
     }

--- a/src/main/java/org/candlepin/insights/task/queue/kafka/KafkaTaskProcessor.java
+++ b/src/main/java/org/candlepin/insights/task/queue/kafka/KafkaTaskProcessor.java
@@ -20,7 +20,6 @@
  */
 package org.candlepin.insights.task.queue.kafka;
 
-
 import org.candlepin.insights.task.TaskDescriptor;
 import org.candlepin.insights.task.TaskExecutionException;
 import org.candlepin.insights.task.TaskFactory;
@@ -32,6 +31,7 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.kafka.annotation.KafkaListener;
 
+import io.micrometer.core.annotation.Timed;
 
 /**
  * Responsible for receiving task messages from Kafka when they become available.
@@ -46,6 +46,7 @@ public class KafkaTaskProcessor {
     }
 
     @KafkaListener(id = "rhsm-conduit-task-processor", topics = "${rhsm-conduit.tasks.task-group}")
+    @Timed("rhsm-conduit.task.execution")
     public void onTaskAvailable(TaskMessage taskMessage) {
         try {
             log.info("Message received from kafka: {}", taskMessage);


### PR DESCRIPTION
# Testing
1. Add a new configuration file, `application.properties` in the `config` directory of the checkout with the following.
```properties
rhsm-conduit.pinhead.url=https://localhost:9180
rhsm-conduit.pinhead.truststore_file=pinhead-client/src/test/resources/server.jks
rhsm-conduit.pinhead.truststore_password=password
rhsm-conduit.pinhead.keystore_file=pinhead-client/src/test/resources/client.jks
rhsm-conduit.pinhead.keystore_password=password

# Uncomment to enable Kafka integration
rhsm-conduit.tasks.queue=kafka
rhsm-conduit.tasks.task-group=rhsm-conduit-tasks
rhsm-conduit.org-sync.fileBasedOrgListStrategy.org-resource-location=file:config/org_sync_list.csv

rhsm-conduit.inventory-service.url=http://localhost:9999

# The number of threads that will be processing messages (should match
# the number of partitions on the queue)
spring.kafka.listener.concurrency=1
spring.kafka.bootstrap-servers=localhost:9092
```
2. Create an HTTP response for the dummy HTTP server(s) to use.  I hit the stage deployment with curl and just saved the response as `config/stage.response`.
```
HTTP/1.1 200 OK
Date: Tue, 13 Aug 2019 18:53:22 GMT
Content-Type: application/json; charset=utf-8

JSON_GOES_HERE
```
3. Start two dummy HTTP servers to mimic pinhead and inventory.
```
$ nc -klv -p 9180 -e '/bin/cat config/stage.response' --ssl --ssl-cert pinhead-client/src/test/resources/server.crt --ssl-key  pinhead-client/src/test/resources/server.key --ssl-trustfile pinhead-client/src/test/resources/client.crt
$ nc -klv -p 9999 -e '/bin/cat config/stage.response'
```
4. Create a `config/org_sync_list.csv file`:
```
Account Number,Candlepin Org ID                                                                                                                    
123,456
7890,1112
1314,1516
```
5. Run the application
```
$ ./gradlew bootRun --args="--server.port=9166 --rhsm-conduit.org-sync.schedule='*/20 * * * * ?' --logging.level.org.candlepin=DEBUG"
```
6. Create a `prometheus.yaml` using the correct IP address for your running deployment:
```
scrape_configs:
 - job_name: rhsm-conduit
   metrics_path: /actuator/prometheus
   static_configs:
   - targets: ['192.168.122.1:9166']
```
7. Start a Prometheus container (you may need to configure SELinux to allow the prometheus.yaml file to get mounted in.  I just set mine to permissive temporarily rather than load a custom module.
```
$ docker run -p 9090:9090 -v /home/awood/devel/rhsm-conduit/prometheus.yaml:/etc/prometheus/prometheus.yml  prom/prometheus
```
8. Go to http://localhost:9090/graph and add expressions to watch the graph!  Try a query like `rhsm_conduit_task_execution_seconds_sum/rhsm_conduit_task_execution_seconds_count` to get the average execution time for the KafkaTaskProcessor