### PR TITLE
ENT-1528: Sync insights ID

### DIFF
--- a/api/rhsm-conduit-api-spec.yaml
+++ b/api/rhsm-conduit-api-spec.yaml
@@ -135,6 +135,8 @@ components:
       properties:
         subscription_manager_id:
           type: string
+        insights_id:
+          type: string
         org_id:
           type: string
         account_number:

--- a/src/main/java/org/candlepin/insights/controller/InventoryController.java
+++ b/src/main/java/org/candlepin/insights/controller/InventoryController.java
@@ -74,6 +74,7 @@ public class InventoryController {
     public static final String MEMORY_MEMTOTAL = "memory.memtotal";
     public static final String UNAME_MACHINE = "uname.machine";
     public static final String VIRT_IS_GUEST = "virt.is_guest";
+    public static final String INSIGHTS_ID = "insights_id";
 
     @Autowired
     private InventoryService inventoryService;
@@ -97,6 +98,7 @@ public class InventoryController {
         facts.setOrgId(consumer.getOrgId());
 
         facts.setSubscriptionManagerId(consumer.getUuid());
+        facts.setInsightsId(pinheadFacts.get(INSIGHTS_ID));
 
         extractNetworkFacts(pinheadFacts, facts);
         extractHardwareFacts(pinheadFacts, facts);

--- a/src/main/java/org/candlepin/insights/inventory/InventoryService.java
+++ b/src/main/java/org/candlepin/insights/inventory/InventoryService.java
@@ -89,6 +89,7 @@ public abstract class InventoryService {
         host.setBiosUuid(conduitFacts.getBiosUuid());
         host.setIpAddresses(conduitFacts.getIpAddresses());
         host.setMacAddresses(conduitFacts.getMacAddresses());
+        host.setInsightsId(conduitFacts.getInsightsId());
         host.facts(facts);
         return host;
     }

--- a/src/test/java/org/candlepin/insights/controller/InventoryControllerTest.java
+++ b/src/test/java/org/candlepin/insights/controller/InventoryControllerTest.java
@@ -238,6 +238,18 @@ public class InventoryControllerTest {
         assertEquals(5, conduitFacts.getIpAddresses().size());
     }
 
+    @Test
+    public void testInsightsIdCollected() {
+        String uuid = UUID.randomUUID().toString();
+        String insightsId = UUID.randomUUID().toString();
+        Consumer consumer = new Consumer();
+        consumer.setUuid(uuid);
+        consumer.getFacts().put(InventoryController.INSIGHTS_ID, insightsId);
+
+        ConduitFacts conduitFacts = controller.getFactsFromConsumer(consumer);
+        assertEquals(insightsId, conduitFacts.getInsightsId());
+    }
+
     private void assertContainSameElements(List<String> list1, List<String> list2) {
         Collections.sort(list1);
         Collections.sort(list2);

--- a/src/test/java/org/candlepin/insights/inventory/DefaultInventoryServiceTest.java
+++ b/src/test/java/org/candlepin/insights/inventory/DefaultInventoryServiceTest.java
@@ -59,6 +59,7 @@ public class DefaultInventoryServiceTest {
         conduitFacts.setOrgId("1234-org");
         conduitFacts.setRhProd(Collections.singletonList("72"));
         conduitFacts.setSubscriptionManagerId("108152b1-6b41-4e1b-b908-922c943e7950");
+        conduitFacts.setInsightsId("0be977bc-46e9-4d9b-a798-65cd1ed98710");
         conduitFacts.setIsVirtual(true);
         conduitFacts.setVmHost("vm_host");
         return conduitFacts;
@@ -84,6 +85,7 @@ public class DefaultInventoryServiceTest {
             .ipAddresses(Collections.singletonList("127.0.0.1"))
             .macAddresses(Collections.singletonList("de:ad:be:ef:fe:ed"))
             .subscriptionManagerId("108152b1-6b41-4e1b-b908-922c943e7950")
+            .insightsId("0be977bc-46e9-4d9b-a798-65cd1ed98710")
             .fqdn("test.example.com")
             .facts(Collections.singletonList(expectedFacts));
 


### PR DESCRIPTION
Now that the insights ID is available in the Pinhead consumer feed, let's fetch it and send over to the inventory.