### PR TITLE
ENT-1544: ignore BIOS UUIDs that don't parse as UUIDs.

### DIFF
--- a/src/main/java/org/candlepin/insights/controller/InventoryController.java
+++ b/src/main/java/org/candlepin/insights/controller/InventoryController.java
@@ -53,6 +53,7 @@ public class InventoryController {
 
     private static final int KIBIBYTES_PER_GIBIBYTE = 1048576;
     private static final String COMMA_REGEX = ",\\s*";
+    private static final String UUID_REGEX = "[0-9a-fA-F]{8}-([0-9a-fA-F]{4}-){3}[0-9a-fA-F]{12}";
 
     public static final String DMI_SYSTEM_UUID = "dmi.system.uuid";
     public static final String MAC_PREFIX = "net.interface.";
@@ -117,7 +118,13 @@ public class InventoryController {
     private void extractHardwareFacts(Map<String, String> pinheadFacts, ConduitFacts facts) {
         String systemUuid = pinheadFacts.get(DMI_SYSTEM_UUID);
         if (!isEmpty(systemUuid)) {
-            facts.setBiosUuid(systemUuid);
+            if (systemUuid.matches(UUID_REGEX)) {
+                facts.setBiosUuid(systemUuid);
+            }
+            else {
+                log.warn("Consumer {} in org {} has unparseable BIOS uuid: {}",
+                    facts.getSubscriptionManagerId(), facts.getOrgId(), systemUuid);
+            }
         }
 
         String cpuSockets = pinheadFacts.get(CPU_SOCKETS);


### PR DESCRIPTION
If a consumer has `dmi.system.uuid` fact that does not parse as an UUID,
do not try to invoke the matching setter in `ConduitFacts` as that would make
the inventory service reject that consumer.