### PR TITLE
Added system purpose data to inventory payload

### DIFF
--- a/api/rhsm-conduit-api-spec.yaml
+++ b/api/rhsm-conduit-api-spec.yaml
@@ -172,6 +172,14 @@ components:
           type: array
           items:
             type: string
+        sys_purpose_role:
+          type: string
+        sys_purpose_usage:
+          type: string
+        sys_purpose_addons:
+          type: array
+          items:
+            type: string
 
     OrgInventory:
       properties:

--- a/src/main/java/org/candlepin/insights/controller/InventoryController.java
+++ b/src/main/java/org/candlepin/insights/controller/InventoryController.java
@@ -104,6 +104,10 @@ public class InventoryController {
         facts.setSubscriptionManagerId(consumer.getUuid());
         facts.setInsightsId(pinheadFacts.get(INSIGHTS_ID));
 
+        facts.setSysPurposeRole(consumer.getSysPurposeRole());
+        facts.setSysPurposeUsage(consumer.getSysPurposeUsage());
+        facts.setSysPurposeAddons(consumer.getSysPurposeAddons());
+
         extractNetworkFacts(pinheadFacts, facts);
         extractHardwareFacts(pinheadFacts, facts);
         extractHypervisorFacts(consumer, pinheadFacts, facts);

--- a/src/main/java/org/candlepin/insights/inventory/DefaultInventoryService.java
+++ b/src/main/java/org/candlepin/insights/inventory/DefaultInventoryService.java
@@ -70,7 +70,7 @@ public class DefaultInventoryService extends InventoryService {
         // The same timestamp for the whole batch
         OffsetDateTime now = OffsetDateTime.now();
         List<CreateHostIn> hostsToSend = facts.stream()
-            .map(x -> createHost(x, now))
+            .map(conduitFacts -> createHost(conduitFacts, now))
             .collect(Collectors.toList());
 
         try {

--- a/src/main/java/org/candlepin/insights/inventory/InventoryService.java
+++ b/src/main/java/org/candlepin/insights/inventory/InventoryService.java
@@ -73,6 +73,15 @@ public abstract class InventoryService {
         if (conduitFacts.getRhProd() != null) {
             rhsmFactMap.put("RH_PROD", conduitFacts.getRhProd());
         }
+        if (conduitFacts.getSysPurposeRole() != null && !conduitFacts.getSysPurposeRole().isEmpty()) {
+            rhsmFactMap.put("SYSPURPOSE_ROLE", conduitFacts.getSysPurposeRole());
+        }
+        if (conduitFacts.getSysPurposeUsage() != null && !conduitFacts.getSysPurposeUsage().isEmpty()) {
+            rhsmFactMap.put("SYSPURPOSE_USAGE", conduitFacts.getSysPurposeUsage());
+        }
+        if (conduitFacts.getSysPurposeAddons() != null) {
+            rhsmFactMap.put("SYSPURPOSE_ADDONS", conduitFacts.getSysPurposeAddons());
+        }
 
         rhsmFactMap.put("SYNC_TIMESTAMP", syncTimestamp);
 

--- a/src/test/java/org/candlepin/insights/inventory/DefaultInventoryServiceTest.java
+++ b/src/test/java/org/candlepin/insights/inventory/DefaultInventoryServiceTest.java
@@ -35,6 +35,7 @@ import org.mockito.Mock;
 import org.mockito.Mockito;
 import org.mockito.junit.jupiter.MockitoExtension;
 
+import java.util.Arrays;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
@@ -62,6 +63,9 @@ public class DefaultInventoryServiceTest {
         conduitFacts.setInsightsId("0be977bc-46e9-4d9b-a798-65cd1ed98710");
         conduitFacts.setIsVirtual(true);
         conduitFacts.setVmHost("vm_host");
+        conduitFacts.setSysPurposeRole("test_role");
+        conduitFacts.setSysPurposeUsage("test_usage");
+        conduitFacts.setSysPurposeAddons(Arrays.asList("addon1", "addon2"));
         return conduitFacts;
     }
 
@@ -78,7 +82,11 @@ public class DefaultInventoryServiceTest {
         expectedFactMap.put("VM_HOST", "vm_host");
         expectedFactMap.put("RH_PROD", Collections.singletonList("72"));
         expectedFactMap.put("orgId", "1234-org");
+        expectedFactMap.put("SYSPURPOSE_ROLE", "test_role");
+        expectedFactMap.put("SYSPURPOSE_USAGE", "test_usage");
+        expectedFactMap.put("SYSPURPOSE_ADDONS", Arrays.asList("addon1", "addon2"));
         FactSet expectedFacts = new FactSet().namespace("rhsm").facts(expectedFactMap);
+
         CreateHostIn expectedHostEntry = new CreateHostIn()
             .account("1234-account")
             .biosUuid("9d9f7927-1f42-4827-bbb8-1791b2b0a1b4")


### PR DESCRIPTION
Pull system purpose attributes from pinhead data and send them
to the inventory service to be stored in the RHSM fact namespace