### PR TITLE
Handle openshift memtotal format

### DIFF
--- a/src/main/java/org/candlepin/insights/controller/InventoryController.java
+++ b/src/main/java/org/candlepin/insights/controller/InventoryController.java
@@ -39,6 +39,8 @@ import java.util.LinkedList;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
 import java.util.stream.Collectors;
 
 import javax.validation.ConstraintViolation;
@@ -145,7 +147,7 @@ public class InventoryController {
         String memoryTotal = pinheadFacts.get(MEMORY_MEMTOTAL);
         if (!isEmpty(memoryTotal)) {
             try {
-                int memoryBytes = Integer.parseInt(memoryTotal);
+                int memoryBytes = memtotalFromString(memoryTotal);
                 // memtotal is a little less than accessible memory, round up to next GB
                 int memoryGigabytes = (int) Math.ceil((float) memoryBytes / (float) KIBIBYTES_PER_GIBIBYTE);
                 facts.setMemory(memoryGigabytes);
@@ -159,6 +161,19 @@ public class InventoryController {
         if (!isEmpty(architecture)) {
             facts.setArchitecture(architecture);
         }
+    }
+
+    protected int memtotalFromString(String memoryTotal) {
+        // Check for match of openshift
+        String patternString = "^\\d+\\.\\d+[Bb]$";
+        Matcher matcher = Pattern.compile(patternString).matcher(memoryTotal);
+
+        String memStr = memoryTotal;
+        // Any other format will throw a NumberFormatException if not a double.
+        if (matcher.matches()) {
+            memStr = memStr.replaceAll("[Bb]", "");
+        }
+        return (int) Math.round(Double.parseDouble(memStr));
     }
 
     @SuppressWarnings("indentation")

--- a/src/test/java/org/candlepin/insights/controller/InventoryControllerTest.java
+++ b/src/test/java/org/candlepin/insights/controller/InventoryControllerTest.java
@@ -183,11 +183,23 @@ public class InventoryControllerTest {
         String uuid = UUID.randomUUID().toString();
         Consumer consumer = new Consumer();
         consumer.setUuid(uuid);
-        consumer.getFacts().put("memory.memtotal", "12345678.00B");
+        consumer.getFacts().put("memory.memtotal", "12345678DDD");
 
         ConduitFacts conduitFacts = controller.getFactsFromConsumer(consumer);
 
         assertNull(conduitFacts.getMemory());
+    }
+
+    @Test
+    public void testHandleOpenShiftStyleMemtotal() {
+        String uuid = UUID.randomUUID().toString();
+        Consumer consumer = new Consumer();
+        consumer.setUuid(uuid);
+        consumer.getFacts().put("memory.memtotal", "32757812.00B");
+
+        ConduitFacts conduitFacts = controller.getFactsFromConsumer(consumer);
+
+        assertEquals(new Integer(32), conduitFacts.getMemory());
     }
 
     @Test
@@ -347,5 +359,17 @@ public class InventoryControllerTest {
         cfacts2.setAccountNumber("account");
         cfacts2.setSubscriptionManagerId(uuid2.toString());
         verify(inventoryService).sendHostUpdate(Mockito.eq(Arrays.asList(cfacts1, cfacts2)));
+    }
+
+    @Test
+    public void memtotalFromString() {
+        assertEquals(12345, controller.memtotalFromString("12345.00B"));
+        assertEquals(12345, controller.memtotalFromString("12345.00b"));
+        assertEquals(12345, controller.memtotalFromString("12345.05"));
+        assertEquals(12346, controller.memtotalFromString("12345.5B"));
+        assertEquals(12345, controller.memtotalFromString("12345"));
+
+        assertThrows(NumberFormatException.class, () -> controller.memtotalFromString("123.00BM"));
+        assertThrows(NumberFormatException.class, () -> controller.memtotalFromString("12B"));
     }
 }


### PR DESCRIPTION
Openshift pods appear to report memory usage in ###.00B for memory reported in bytes.
Strip everything after the decimal and convert that value before sending to inventory