### PR TITLE
Resource usage optimizations and additional logging

### DIFF
--- a/insights-inventory-client/src/main/java/org/candlepin/insights/inventory/client/InventoryServiceProperties.java
+++ b/insights-inventory-client/src/main/java/org/candlepin/insights/inventory/client/InventoryServiceProperties.java
@@ -29,6 +29,7 @@ public class InventoryServiceProperties {
     private String apiKey;
     private boolean enableKafka;
     private String kafkaHostIngressTopic = "platform.inventory.host-ingress";
+    private int apiHostUpdateBatchSize = 50;
 
     public boolean isUseStub() {
         return useStub;
@@ -52,6 +53,14 @@ public class InventoryServiceProperties {
 
     public void setApiKey(String apiKey) {
         this.apiKey = apiKey;
+    }
+
+    public int getApiHostUpdateBatchSize() {
+        return apiHostUpdateBatchSize;
+    }
+
+    public void setApiHostUpdateBatchSize(int apiHostUpdateBatchSize) {
+        this.apiHostUpdateBatchSize = apiHostUpdateBatchSize;
     }
 
     public boolean isEnableKafka() {

--- a/pinhead-client/src/main/java/org/candlepin/insights/pinhead/client/PinheadApiProperties.java
+++ b/pinhead-client/src/main/java/org/candlepin/insights/pinhead/client/PinheadApiProperties.java
@@ -33,6 +33,7 @@ public class PinheadApiProperties {
     private final X509ApiClientFactoryConfiguration x509Config = new X509ApiClientFactoryConfiguration();
     private boolean useStub;
     private String url;
+    private int requestBatchSize = 100;
 
     public boolean isUseStub() {
         return useStub;
@@ -104,5 +105,13 @@ public class PinheadApiProperties {
 
     public boolean usesClientAuth() {
         return x509Config.usesClientAuth();
+    }
+
+    public int getRequestBatchSize() {
+        return requestBatchSize;
+    }
+
+    public void setRequestBatchSize(int requestBatchSize) {
+        this.requestBatchSize = requestBatchSize;
     }
 }

--- a/src/main/java/org/candlepin/insights/controller/InventoryController.java
+++ b/src/main/java/org/candlepin/insights/controller/InventoryController.java
@@ -289,7 +289,8 @@ public class InventoryController {
     public void updateInventoryForOrg(String orgId) {
         List<ConduitFacts> conduitFactsForOrg = getValidatedConsumers(orgId);
         inventoryService.sendHostUpdate(conduitFactsForOrg);
-        log.info("Host inventory update completed for org: {}", orgId);
+        log.info("Host inventory update completed for org {}. Consumers: {}", orgId,
+            conduitFactsForOrg.size());
     }
 
     public OrgInventory getInventoryForOrg(String orgId) {

--- a/src/main/java/org/candlepin/insights/inventory/InventoryServiceConfiguration.java
+++ b/src/main/java/org/candlepin/insights/inventory/InventoryServiceConfiguration.java
@@ -65,8 +65,8 @@ public class InventoryServiceConfiguration {
     @Bean
     @ConditionalOnProperty(prefix = "rhsm-conduit.inventory-service", name = "enableKafka",
         havingValue = "false", matchIfMissing = true)
-    public InventoryService apiInventoryService(HostsApi hostsApi) {
-        return new DefaultInventoryService(hostsApi);
+    public InventoryService apiInventoryService(InventoryServiceProperties props, HostsApi hostsApi) {
+        return new DefaultInventoryService(hostsApi, props.getApiHostUpdateBatchSize());
     }
 
     //

--- a/src/main/java/org/candlepin/insights/pinhead/PinheadService.java
+++ b/src/main/java/org/candlepin/insights/pinhead/PinheadService.java
@@ -27,6 +27,8 @@ import org.candlepin.insights.pinhead.client.model.OrgInventory;
 import org.candlepin.insights.pinhead.client.model.Status;
 import org.candlepin.insights.pinhead.client.resources.PinheadApi;
 
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.retry.RetryCallback;
@@ -49,6 +51,8 @@ public class PinheadService {
 
     private class PagedConsumerIterator implements Iterator<Consumer> {
 
+        private final Logger log = LoggerFactory.getLogger(PagedConsumerIterator.class);
+
         private final String orgId;
 
         private List<Consumer> consumers;
@@ -62,6 +66,7 @@ public class PinheadService {
         private void fetchPage() {
             try {
                 retryTemplate.execute((RetryCallback<Void, ApiException>) context -> {
+                    log.debug("Fetching next page of consumers for org {}.", orgId);
                     OrgInventory consumersForOrg = api.getConsumersForOrg(orgId, batchSize, nextOffset);
                     consumers = consumersForOrg.getFeeds();
                     Status status = consumersForOrg.getStatus();
@@ -71,6 +76,8 @@ public class PinheadService {
                     else {
                         nextOffset = null;
                     }
+                    log.debug("Consumer fetch complete. Found {} for batch of {}.", consumers.size(),
+                        batchSize);
                     return null;
                 });
             }

--- a/src/test/java/org/candlepin/insights/inventory/kafka/KafkaEnabledInventoryServiceTest.java
+++ b/src/test/java/org/candlepin/insights/inventory/kafka/KafkaEnabledInventoryServiceTest.java
@@ -22,6 +22,10 @@ package org.candlepin.insights.inventory.kafka;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.verifyZeroInteractions;
 import static org.mockito.Mockito.when;
 
@@ -91,5 +95,15 @@ public class KafkaEnabledInventoryServiceTest {
         service.sendHostUpdate(Arrays.asList());
 
         verifyZeroInteractions(producer);
+    }
+
+    @Test
+    public void ensureMessageSentWhenHostUpdateScheduled() {
+        InventoryServiceProperties props = new InventoryServiceProperties();
+        KafkaEnabledInventoryService service = new KafkaEnabledInventoryService(props, producer);
+        service.scheduleHostUpdate(new ConduitFacts());
+        service.scheduleHostUpdate(new ConduitFacts());
+
+        verify(producer, times(2)).send(anyString(), any());
     }
 }

--- a/src/test/java/org/candlepin/insights/pinhead/PinheadServiceTest.java
+++ b/src/test/java/org/candlepin/insights/pinhead/PinheadServiceTest.java
@@ -24,6 +24,7 @@ import static org.junit.jupiter.api.Assertions.*;
 import static org.mockito.Mockito.*;
 
 import org.candlepin.insights.pinhead.client.ApiException;
+import org.candlepin.insights.pinhead.client.PinheadApiProperties;
 import org.candlepin.insights.pinhead.client.model.Consumer;
 import org.candlepin.insights.pinhead.client.model.OrgInventory;
 import org.candlepin.insights.pinhead.client.model.Pagination;
@@ -88,7 +89,7 @@ public class PinheadServiceTest {
                 }
             }
         };
-        PinheadService service = new PinheadService(testApi, retryTemplate);
+        PinheadService service = new PinheadService(new PinheadApiProperties(), testApi, retryTemplate);
         List<Consumer> consumers = new ArrayList<>();
         service.getOrganizationConsumers("123").forEach(consumers::add);
         assertEquals(4, consumers.size());
@@ -107,7 +108,7 @@ public class PinheadServiceTest {
 
         // Make the tests run faster!
         retryTemplate.setBackOffPolicy(new NoBackOffPolicy());
-        PinheadService service = new PinheadService(testApi, retryTemplate);
+        PinheadService service = new PinheadService(new PinheadApiProperties(), testApi, retryTemplate);
         List<Consumer> consumers = new ArrayList<>();
         assertThrows(RuntimeException.class,
             () -> service.getOrganizationConsumers("123").forEach(consumers::add)


### PR DESCRIPTION
This patch is a combination of a few items that came out of debugging rhsm-conduit in production.

**1. Made pinhead service's batch size configurable**

**2. Added some additional debug logging around paging in the pinhead service**

**3. Support batching inventory updates**

As data is pulled from pinhead, support batch sending to inventory.
Prior to this patch, data was being paged while pulling from pinhead,
however, we were storing all generated conduit facts in memory until
all pinhead records for an org were recieved.

This patch allows the inventory service to batch send fact updates
as data is being read from pinhead reducing the memory footprint.

The DefaultInventoryService will batch fact updates as each record
from pinhead is read. Once the configured max queue depth (default
100) records are read, the service will automatically send the updates
to inventory.

The KafkaEnabledInventoryService will send an inventory update
message as soon as a record from pinhead is recieved (no queuing
at all).