### PR TITLE
Make the source compatible with RHEL-based java images

### DIFF
--- a/.s2i/bin/assemble
+++ b/.s2i/bin/assemble
@@ -1,0 +1,3 @@
+cd /tmp/src
+./gradlew assemble
+cp build/libs/* /deployments/


### PR DESCRIPTION
Such as:

  - `registry.access.redhat.com/redhat-openjdk-18/openjdk18-openshift`
  - `registry.redhat.io/openjdk/openjdk-8-rhel8`

Also, it stays compatible with `docker.io/fabric8/s2i-java`

To test, try:

```
s2i build . registry.access.redhat.com/redhat-openjdk-18/openjdk18-openshift test
```

(modify the image reference as desired) followed by running the resulting container image:

```
docker run --rm test
```

Note: if you want to try the registry.redhat.io image, you'll need to do `docker login registry.redhat.io` first.

The primary difference between those images and the fabric8 ones we've been using is that the RHEL-based ones don't directly support gradle, so we have to be explicit about build steps.