### PR TITLE
Add stale_timestamp and reporter fields to inventory host data

### DIFF
--- a/insights-inventory-client/src/main/java/org/candlepin/insights/inventory/client/InventoryServiceProperties.java
+++ b/insights-inventory-client/src/main/java/org/candlepin/insights/inventory/client/InventoryServiceProperties.java
@@ -30,6 +30,7 @@ public class InventoryServiceProperties {
     private boolean enableKafka;
     private String kafkaHostIngressTopic = "platform.inventory.host-ingress";
     private int apiHostUpdateBatchSize = 50;
+    private int staleHostOffsetInDays = 0;
 
     public boolean isUseStub() {
         return useStub;
@@ -61,6 +62,14 @@ public class InventoryServiceProperties {
 
     public void setApiHostUpdateBatchSize(int apiHostUpdateBatchSize) {
         this.apiHostUpdateBatchSize = apiHostUpdateBatchSize;
+    }
+
+    public int getStaleHostOffsetInDays() {
+        return staleHostOffsetInDays;
+    }
+
+    public void setStaleHostOffsetInDays(int staleHostOffsetInDays) {
+        this.staleHostOffsetInDays = staleHostOffsetInDays;
     }
 
     public boolean isEnableKafka() {

--- a/src/main/java/org/candlepin/insights/inventory/DefaultInventoryService.java
+++ b/src/main/java/org/candlepin/insights/inventory/DefaultInventoryService.java
@@ -40,8 +40,8 @@ public class DefaultInventoryService extends InventoryService {
 
     private final HostsApi hostsInventoryApi;
 
-    public DefaultInventoryService(HostsApi hostsInventoryApi, int maxQueueDepth) {
-        super(maxQueueDepth);
+    public DefaultInventoryService(HostsApi hostsInventoryApi, int maxQueueDepth, int staleHostOffset) {
+        super(maxQueueDepth, staleHostOffset);
         this.hostsInventoryApi = hostsInventoryApi;
     }
 

--- a/src/main/java/org/candlepin/insights/inventory/DefaultInventoryService.java
+++ b/src/main/java/org/candlepin/insights/inventory/DefaultInventoryService.java
@@ -21,6 +21,7 @@
 package org.candlepin.insights.inventory;
 
 import org.candlepin.insights.exception.inventory.InventoryServiceException;
+import org.candlepin.insights.inventory.client.InventoryServiceProperties;
 import org.candlepin.insights.inventory.client.model.CreateHostIn;
 import org.candlepin.insights.inventory.client.resources.HostsApi;
 
@@ -40,8 +41,8 @@ public class DefaultInventoryService extends InventoryService {
 
     private final HostsApi hostsInventoryApi;
 
-    public DefaultInventoryService(HostsApi hostsInventoryApi, int maxQueueDepth, int staleHostOffset) {
-        super(maxQueueDepth, staleHostOffset);
+    public DefaultInventoryService(HostsApi hostsInventoryApi, InventoryServiceProperties serviceProperties) {
+        super(serviceProperties, serviceProperties.getApiHostUpdateBatchSize());
         this.hostsInventoryApi = hostsInventoryApi;
     }
 

--- a/src/main/java/org/candlepin/insights/inventory/InventoryService.java
+++ b/src/main/java/org/candlepin/insights/inventory/InventoryService.java
@@ -22,6 +22,7 @@ package org.candlepin.insights.inventory;
 
 import org.candlepin.insights.api.model.ConsumerInventory;
 import org.candlepin.insights.api.model.OrgInventory;
+import org.candlepin.insights.inventory.client.InventoryServiceProperties;
 import org.candlepin.insights.inventory.client.model.CreateHostIn;
 import org.candlepin.insights.inventory.client.model.FactSet;
 
@@ -49,9 +50,9 @@ public abstract class InventoryService {
     private int staleHostOffset;
     private List<ConduitFacts> factQueue;
 
-    public InventoryService(int maxQueueDepth, int staleHostOffset) {
+    public InventoryService(InventoryServiceProperties serviceProperties, int maxQueueDepth) {
         this.maxQueueDepth = maxQueueDepth;
-        this.staleHostOffset = staleHostOffset;
+        this.staleHostOffset = serviceProperties.getStaleHostOffsetInDays();
         this.factQueue = new LinkedList<>();
     }
 

--- a/src/main/java/org/candlepin/insights/inventory/InventoryServiceConfiguration.java
+++ b/src/main/java/org/candlepin/insights/inventory/InventoryServiceConfiguration.java
@@ -65,9 +65,8 @@ public class InventoryServiceConfiguration {
     @Bean
     @ConditionalOnProperty(prefix = "rhsm-conduit.inventory-service", name = "enableKafka",
         havingValue = "false", matchIfMissing = true)
-    public InventoryService apiInventoryService(InventoryServiceProperties props, HostsApi hostsApi) {
-        return new DefaultInventoryService(hostsApi, props.getApiHostUpdateBatchSize(),
-            props.getStaleHostOffsetInDays());
+    public InventoryService apiInventoryService(InventoryServiceProperties serviceProps, HostsApi hostsApi) {
+        return new DefaultInventoryService(hostsApi, serviceProps);
     }
 
     //
@@ -118,7 +117,6 @@ public class InventoryServiceConfiguration {
         @Qualifier("inventoryServiceKafkaProducerTemplate")
         KafkaTemplate<String, HostOperationMessage> producer,
         InventoryServiceProperties serviceProperties) {
-        return new KafkaEnabledInventoryService(serviceProperties.getKafkaHostIngressTopic(),
-            serviceProperties.getStaleHostOffsetInDays(), producer);
+        return new KafkaEnabledInventoryService(serviceProperties, producer);
     }
 }

--- a/src/main/java/org/candlepin/insights/inventory/InventoryServiceConfiguration.java
+++ b/src/main/java/org/candlepin/insights/inventory/InventoryServiceConfiguration.java
@@ -66,7 +66,8 @@ public class InventoryServiceConfiguration {
     @ConditionalOnProperty(prefix = "rhsm-conduit.inventory-service", name = "enableKafka",
         havingValue = "false", matchIfMissing = true)
     public InventoryService apiInventoryService(InventoryServiceProperties props, HostsApi hostsApi) {
-        return new DefaultInventoryService(hostsApi, props.getApiHostUpdateBatchSize());
+        return new DefaultInventoryService(hostsApi, props.getApiHostUpdateBatchSize(),
+            props.getStaleHostOffsetInDays());
     }
 
     //
@@ -116,7 +117,8 @@ public class InventoryServiceConfiguration {
     public InventoryService kafkaInventoryService(
         @Qualifier("inventoryServiceKafkaProducerTemplate")
         KafkaTemplate<String, HostOperationMessage> producer,
-        InventoryServiceProperties inventoryServiceProperties) {
-        return new KafkaEnabledInventoryService(inventoryServiceProperties, producer);
+        InventoryServiceProperties serviceProperties) {
+        return new KafkaEnabledInventoryService(serviceProperties.getKafkaHostIngressTopic(),
+            serviceProperties.getStaleHostOffsetInDays(), producer);
     }
 }

--- a/src/main/java/org/candlepin/insights/inventory/kafka/KafkaEnabledInventoryService.java
+++ b/src/main/java/org/candlepin/insights/inventory/kafka/KafkaEnabledInventoryService.java
@@ -22,7 +22,6 @@ package org.candlepin.insights.inventory.kafka;
 
 import org.candlepin.insights.inventory.ConduitFacts;
 import org.candlepin.insights.inventory.InventoryService;
-import org.candlepin.insights.inventory.client.InventoryServiceProperties;
 
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -43,12 +42,12 @@ public class KafkaEnabledInventoryService extends InventoryService {
     private final KafkaTemplate<String, HostOperationMessage> producer;
     private final String hostIngressTopic;
 
-    public KafkaEnabledInventoryService(InventoryServiceProperties inventoryServiceProperties,
+    public KafkaEnabledInventoryService(String hostIngressTopic, int hostStaleOffset,
         KafkaTemplate<String, HostOperationMessage> producer) {
         // Flush updates as soon as they get scheduled.
-        super(1);
+        super(1, hostStaleOffset);
         this.producer = producer;
-        this.hostIngressTopic = inventoryServiceProperties.getKafkaHostIngressTopic();
+        this.hostIngressTopic = hostIngressTopic;
     }
 
     @Override

--- a/src/main/java/org/candlepin/insights/inventory/kafka/KafkaEnabledInventoryService.java
+++ b/src/main/java/org/candlepin/insights/inventory/kafka/KafkaEnabledInventoryService.java
@@ -22,6 +22,7 @@ package org.candlepin.insights.inventory.kafka;
 
 import org.candlepin.insights.inventory.ConduitFacts;
 import org.candlepin.insights.inventory.InventoryService;
+import org.candlepin.insights.inventory.client.InventoryServiceProperties;
 
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -42,12 +43,12 @@ public class KafkaEnabledInventoryService extends InventoryService {
     private final KafkaTemplate<String, HostOperationMessage> producer;
     private final String hostIngressTopic;
 
-    public KafkaEnabledInventoryService(String hostIngressTopic, int hostStaleOffset,
+    public KafkaEnabledInventoryService(InventoryServiceProperties serviceProperties,
         KafkaTemplate<String, HostOperationMessage> producer) {
         // Flush updates as soon as they get scheduled.
-        super(1, hostStaleOffset);
+        super(serviceProperties, 1);
         this.producer = producer;
-        this.hostIngressTopic = hostIngressTopic;
+        this.hostIngressTopic = serviceProperties.getKafkaHostIngressTopic();
     }
 
     @Override

--- a/src/test/java/org/candlepin/insights/inventory/kafka/KafkaEnabledInventoryServiceTest.java
+++ b/src/test/java/org/candlepin/insights/inventory/kafka/KafkaEnabledInventoryServiceTest.java
@@ -66,8 +66,7 @@ public class KafkaEnabledInventoryServiceTest {
         expectedFacts.setCpuSockets(45);
 
         InventoryServiceProperties props = new InventoryServiceProperties();
-        KafkaEnabledInventoryService service = new KafkaEnabledInventoryService(
-            props.getKafkaHostIngressTopic(), props.getStaleHostOffsetInDays(), producer);
+        KafkaEnabledInventoryService service = new KafkaEnabledInventoryService(props, producer);
         service.sendHostUpdate(Arrays.asList(expectedFacts));
 
         assertEquals(props.getKafkaHostIngressTopic(), topicCaptor.getValue());
@@ -97,8 +96,7 @@ public class KafkaEnabledInventoryServiceTest {
     @Test
     public void ensureNoMessageWithEmptyFactList() {
         InventoryServiceProperties props = new InventoryServiceProperties();
-        KafkaEnabledInventoryService service = new KafkaEnabledInventoryService(
-            props.getKafkaHostIngressTopic(), props.getStaleHostOffsetInDays(), producer);
+        KafkaEnabledInventoryService service = new KafkaEnabledInventoryService(props, producer);
         service.sendHostUpdate(Arrays.asList());
 
         verifyZeroInteractions(producer);
@@ -107,8 +105,7 @@ public class KafkaEnabledInventoryServiceTest {
     @Test
     public void ensureMessageSentWhenHostUpdateScheduled() {
         InventoryServiceProperties props = new InventoryServiceProperties();
-        KafkaEnabledInventoryService service = new KafkaEnabledInventoryService(
-            props.getKafkaHostIngressTopic(), props.getStaleHostOffsetInDays(), producer);
+        KafkaEnabledInventoryService service = new KafkaEnabledInventoryService(props, producer);
         service.scheduleHostUpdate(new ConduitFacts());
         service.scheduleHostUpdate(new ConduitFacts());
 
@@ -127,8 +124,9 @@ public class KafkaEnabledInventoryServiceTest {
         expectedFacts.setAccountNumber("my_account");
 
         InventoryServiceProperties props = new InventoryServiceProperties();
-        KafkaEnabledInventoryService service = new KafkaEnabledInventoryService(
-            props.getKafkaHostIngressTopic(), 24, producer);
+        props.setStaleHostOffsetInDays(24);
+
+        KafkaEnabledInventoryService service = new KafkaEnabledInventoryService(props, producer);
         service.sendHostUpdate(Arrays.asList(expectedFacts));
 
         CreateUpdateHostMessage message = messageCaptor.getValue();

--- a/src/test/java/org/candlepin/insights/inventory/kafka/KafkaEnabledInventoryServiceTest.java
+++ b/src/test/java/org/candlepin/insights/inventory/kafka/KafkaEnabledInventoryServiceTest.java
@@ -40,6 +40,7 @@ import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 import org.springframework.kafka.core.KafkaTemplate;
 
+import java.time.OffsetDateTime;
 import java.util.Arrays;
 import java.util.Map;
 
@@ -51,7 +52,6 @@ public class KafkaEnabledInventoryServiceTest {
 
     @Test
     public void ensureKafkaProducerSendsHostMessage() {
-
         ArgumentCaptor<String> topicCaptor = ArgumentCaptor.forClass(String.class);
         ArgumentCaptor<CreateUpdateHostMessage> messageCaptor =
             ArgumentCaptor.forClass(CreateUpdateHostMessage.class);
@@ -66,7 +66,8 @@ public class KafkaEnabledInventoryServiceTest {
         expectedFacts.setCpuSockets(45);
 
         InventoryServiceProperties props = new InventoryServiceProperties();
-        KafkaEnabledInventoryService service = new KafkaEnabledInventoryService(props, producer);
+        KafkaEnabledInventoryService service = new KafkaEnabledInventoryService(
+            props.getKafkaHostIngressTopic(), props.getStaleHostOffsetInDays(), producer);
         service.sendHostUpdate(Arrays.asList(expectedFacts));
 
         assertEquals(props.getKafkaHostIngressTopic(), topicCaptor.getValue());
@@ -86,12 +87,18 @@ public class KafkaEnabledInventoryServiceTest {
         assertEquals(expectedFacts.getOrgId(), (String) rhsmFacts.get("orgId"));
         assertEquals(expectedFacts.getCpuCores(), (Integer) rhsmFacts.get("CPU_CORES"));
         assertEquals(expectedFacts.getCpuSockets(), (Integer) rhsmFacts.get("CPU_SOCKETS"));
+
+        OffsetDateTime syncDate = (OffsetDateTime) rhsmFacts.get("SYNC_TIMESTAMP");
+        assertNotNull(syncDate);
+        assertEquals(syncDate, message.getData().getStaleTimestamp());
+        assertEquals("rhsm-conduit", message.getData().getReporter());
     }
 
     @Test
     public void ensureNoMessageWithEmptyFactList() {
         InventoryServiceProperties props = new InventoryServiceProperties();
-        KafkaEnabledInventoryService service = new KafkaEnabledInventoryService(props, producer);
+        KafkaEnabledInventoryService service = new KafkaEnabledInventoryService(
+            props.getKafkaHostIngressTopic(), props.getStaleHostOffsetInDays(), producer);
         service.sendHostUpdate(Arrays.asList());
 
         verifyZeroInteractions(producer);
@@ -100,10 +107,43 @@ public class KafkaEnabledInventoryServiceTest {
     @Test
     public void ensureMessageSentWhenHostUpdateScheduled() {
         InventoryServiceProperties props = new InventoryServiceProperties();
-        KafkaEnabledInventoryService service = new KafkaEnabledInventoryService(props, producer);
+        KafkaEnabledInventoryService service = new KafkaEnabledInventoryService(
+            props.getKafkaHostIngressTopic(), props.getStaleHostOffsetInDays(), producer);
         service.scheduleHostUpdate(new ConduitFacts());
         service.scheduleHostUpdate(new ConduitFacts());
 
         verify(producer, times(2)).send(anyString(), any());
+    }
+
+    @Test
+    public void testStaleTimestampUpdatedBasedOnSyncTimestampAndOffset() {
+        ArgumentCaptor<String> topicCaptor = ArgumentCaptor.forClass(String.class);
+        ArgumentCaptor<CreateUpdateHostMessage> messageCaptor =
+            ArgumentCaptor.forClass(CreateUpdateHostMessage.class);
+
+        when(producer.send(topicCaptor.capture(), messageCaptor.capture())).thenReturn(null);
+
+        ConduitFacts expectedFacts = new ConduitFacts();
+        expectedFacts.setAccountNumber("my_account");
+
+        InventoryServiceProperties props = new InventoryServiceProperties();
+        KafkaEnabledInventoryService service = new KafkaEnabledInventoryService(
+            props.getKafkaHostIngressTopic(), 24, producer);
+        service.sendHostUpdate(Arrays.asList(expectedFacts));
+
+        CreateUpdateHostMessage message = messageCaptor.getValue();
+        assertNotNull(message);
+        assertEquals("add_host", message.getOperation());
+        assertEquals(expectedFacts.getAccountNumber(), message.getData().getAccount());
+
+        assertNotNull(message.getData().getFacts());
+        assertEquals(1, message.getData().getFacts().size());
+        FactSet rhsm = message.getData().getFacts().get(0);
+        assertEquals("rhsm", rhsm.getNamespace());
+
+        Map<String, Object> rhsmFacts = (Map<String, Object>) rhsm.getFacts();
+        OffsetDateTime syncDate = (OffsetDateTime) rhsmFacts.get("SYNC_TIMESTAMP");
+        assertNotNull(syncDate);
+        assertEquals(syncDate.plusHours(24), message.getData().getStaleTimestamp());
     }
 }


### PR DESCRIPTION
The stale_timestamp value is calculated by adding the configurable
staleHostOffsetInDays property to the current time. By default the
offset is zero.

This data was added to support host culling in the inventory service.
The data is being sent when using both the inventory REST and MQ APIs.