### PR TITLE
Fixes to address the offset commit failure messages on large orgs

### DIFF
--- a/src/main/java/org/candlepin/insights/inventory/InventoryService.java
+++ b/src/main/java/org/candlepin/insights/inventory/InventoryService.java
@@ -70,12 +70,14 @@ public abstract class InventoryService {
      * @param facts the host facts to schedule for update.
      */
     public void scheduleHostUpdate(ConduitFacts facts) {
-        factQueue.add(facts);
+        synchronized (factQueue) {
+            factQueue.add(facts);
 
-        // Auto flush updates when max queue depth is reached.
-        if (factQueue.size() == maxQueueDepth) {
-            log.debug("Max queue depth reached. Auto flusing updates.");
-            flushHostUpdates();
+            // Auto flush updates when max queue depth is reached.
+            if (factQueue.size() == maxQueueDepth) {
+                log.debug("Max queue depth reached. Auto flusing updates.");
+                flushHostUpdates();
+            }
         }
     }
 
@@ -83,9 +85,11 @@ public abstract class InventoryService {
      * Force the currently scheduled updates to be sent to inventory.
      */
     public void flushHostUpdates() {
-        if (!factQueue.isEmpty()) {
-            sendHostUpdate(factQueue);
-            factQueue.clear();
+        synchronized (factQueue) {
+            if (!factQueue.isEmpty()) {
+                sendHostUpdate(factQueue);
+                factQueue.clear();
+            }
         }
     }
 

--- a/src/main/java/org/candlepin/insights/task/queue/kafka/KafkaTaskProcessor.java
+++ b/src/main/java/org/candlepin/insights/task/queue/kafka/KafkaTaskProcessor.java
@@ -51,18 +51,15 @@ public class KafkaTaskProcessor {
     public void receive(TaskMessage taskMessage, Acknowledgment acknowledgment) {
         try {
             log.info("Message received from kafka: {}", taskMessage);
+            // Ack the message early so that if kafka times out, the message has already been acked
+            // and will not get retried.
+            acknowledgment.acknowledge();
             worker.executeTask(describe(taskMessage));
         }
         catch (TaskExecutionException e) {
             // If a task fails to execute for any reason, it is logged and will
             // not get retried.
             log.error("Failed to execute task: {}", taskMessage, e);
-        }
-        finally {
-            // We always ack the message regardless of if there are failures.
-            // There is no need to retry the message on failure since the task
-            // can either be manually re-triggered or will run on the next schedule.
-            acknowledgment.acknowledge();
         }
     }
 

--- a/src/main/resources/rhsm-conduit.properties
+++ b/src/main/resources/rhsm-conduit.properties
@@ -14,6 +14,9 @@ rhsm-conduit.org-sync.strategy = fileBasedOrgListStrategy
 # Use Spring Resource notation for this (e.g. "classpath:" or "file:")
 rhsm-conduit.org-sync.fileBasedOrgListStrategy.org-resource-location=classpath:empty-org-list.txt
 
+# Pinhead service default properties
+rhsm-conduit.pinhead.requestBatchSize=1000
+
 # The API key configured by the inventory service.
 rhsm-conduit.inventory-service.apiKey=changeit
 
@@ -32,6 +35,10 @@ rhsm-conduit.datasource.platform=hsqldb
 # Uncomment to enable Kafka integration
 #rhsm-conduit.tasks.queue=kafka
 #rhsm-conduit.tasks.task-group=rhsm-conduit-tasks
+
+# Required kafka defaults
+spring.kafka.consumer.properties.max.poll.records=1
+spring.kafka.consumer.properties.max.poll.interval.ms=1800000
 
 # The number of threads that will be processing messages (should match
 # the number of partitions on the queue)


### PR DESCRIPTION
When this is deployed, we will require the following config additions:
```
rhsm-conduit.pinhead.requestBatchSize=1000
spring.kafka.consumer.properties.max.poll.records=1
spring.kafka.consumer.properties.max.poll.interval.ms=1800000
```