### PR TITLE
Do not import systems older than N days into insights inventory.

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -262,6 +262,10 @@ project(":insights-inventory-client") {
         api_spec_path = "https://raw.githubusercontent.com/RedHatInsights/insights-host-inventory/master/swagger/api.spec.yaml"
         config_file = "${projectDir}/insights-inventory-client-config.json"
     }
+
+    dependencies {
+        compileOnly 'org.springframework.boot:spring-boot'
+    }
 }
 
 project(":pinhead-client") {

--- a/insights-inventory-client/src/main/java/org/candlepin/insights/inventory/client/InventoryServiceProperties.java
+++ b/insights-inventory-client/src/main/java/org/candlepin/insights/inventory/client/InventoryServiceProperties.java
@@ -20,6 +20,11 @@
  */
 package org.candlepin.insights.inventory.client;
 
+import org.springframework.boot.convert.DurationUnit;
+
+import java.time.Duration;
+import java.time.temporal.ChronoUnit;
+
 /**
  * Sub-class for inventory service properties
  */
@@ -31,6 +36,9 @@ public class InventoryServiceProperties {
     private String kafkaHostIngressTopic = "platform.inventory.host-ingress";
     private int apiHostUpdateBatchSize = 50;
     private int staleHostOffsetInDays = 0;
+
+    @DurationUnit(ChronoUnit.HOURS)
+    private Duration hostLastSyncThreshold = Duration.ofHours(24);
 
     public boolean isUseStub() {
         return useStub;
@@ -86,5 +94,13 @@ public class InventoryServiceProperties {
 
     public void setKafkaHostIngressTopic(String kafkaHostIngressTopic) {
         this.kafkaHostIngressTopic = kafkaHostIngressTopic;
+    }
+
+    public Duration getHostLastSyncThreshold() {
+        return hostLastSyncThreshold;
+    }
+
+    public void setHostLastSyncThreshold(Duration hostLastSyncThreshold) {
+        this.hostLastSyncThreshold = hostLastSyncThreshold;
     }
 }

--- a/src/main/resources/rhsm-conduit.properties
+++ b/src/main/resources/rhsm-conduit.properties
@@ -19,6 +19,7 @@ rhsm-conduit.pinhead.requestBatchSize=1000
 
 # The API key configured by the inventory service.
 rhsm-conduit.inventory-service.apiKey=changeit
+#rhsm-conduit.inventory-service.host-last-sync-threshold=24h
 
 # Inventory service kafka configuration
 #rhsm-conduit.inventory-service.enableKafka=true


### PR DESCRIPTION
The value N is configurable according to the [duration conversions in
Spring Boot](https://docs.spring.io/spring-boot/docs/current/reference/htmlsingle/#boot-features-external-config-conversion-duration) (e.g. 24h, 1d, 86400s).  Systems that don't have a last
check-in time (or are checked in from the future) are imported too.