### PR TITLE
Restore sonarcloud code coverage

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -12,7 +12,7 @@ plugins {
     id "io.spring.dependency-management" version "1.0.8.RELEASE"
     id "checkstyle"
     id "jacoco"
-    id "org.sonarqube" version "2.7"
+    id "org.sonarqube" version "2.8"
     id "org.springframework.boot" version "2.0.8.RELEASE"
     id "net.researchgate.release" version "2.6.0"
     id "GitProperties"
@@ -57,6 +57,12 @@ allprojects {
 
     checkstyle {
         toolVersion "8.16"
+    }
+
+    jacocoTestReport {
+        reports {
+            xml.enabled true
+        }
     }
 
     group = "org.candlepin"

--- a/build.gradle
+++ b/build.gradle
@@ -192,6 +192,8 @@ dependencies {
 }
 
 compileJava.dependsOn(processResources)
+project.tasks["sonarqube"].dependsOn "test"
+project.tasks["sonarqube"].dependsOn "jacocoTestReport"
 
 project(":api") {
     apply plugin: "org.openapi.generator"


### PR DESCRIPTION
I tested manually by running the `./gradlew sonarqube ...` command that is used from the `Jenkinsfile`, and verified that it restored code coverage to the project dashboard on sonarcloud.io. I will make a PR for rhsm-subscriptions too.