### PR TITLE
Add artificial org limit & improve org list query

### DIFF
--- a/src/main/java/org/candlepin/insights/orgsync/OrgSyncProperties.java
+++ b/src/main/java/org/candlepin/insights/orgsync/OrgSyncProperties.java
@@ -32,6 +32,8 @@ public class OrgSyncProperties {
     // Default to every 5 minutes
     private String schedule = "0 5 * * * ?";
     private String strategy = FileBasedOrgListStrategy.class.getSimpleName();
+    /** Artificial limit to number of orgs */
+    private Integer limit = null;
 
     public String getSchedule() {
         return schedule;
@@ -47,5 +49,13 @@ public class OrgSyncProperties {
 
     public void setStrategy(String strategy) {
         this.strategy = strategy;
+    }
+
+    public Integer getLimit() {
+        return limit;
+    }
+
+    public void setLimit(Integer limit) {
+        this.limit = limit;
     }
 }

--- a/src/main/java/org/candlepin/insights/orgsync/db/DatabaseOrgListStrategy.java
+++ b/src/main/java/org/candlepin/insights/orgsync/db/DatabaseOrgListStrategy.java
@@ -23,7 +23,6 @@ package org.candlepin.insights.orgsync.db;
 import org.candlepin.insights.orgsync.OrgListStrategy;
 
 import java.util.List;
-import java.util.stream.Collectors;
 
 /**
  * Pulls the list of orgs to sync from a database table.
@@ -40,6 +39,6 @@ public class DatabaseOrgListStrategy implements OrgListStrategy {
 
     @Override
     public List<String> getOrgsToSync() {
-        return repo.findAll().stream().map(Organization::getId).collect(Collectors.toList());
+        return repo.getOrgIdList();
     }
 }

--- a/src/main/java/org/candlepin/insights/orgsync/db/OrganizationRepository.java
+++ b/src/main/java/org/candlepin/insights/orgsync/db/OrganizationRepository.java
@@ -21,10 +21,14 @@
 package org.candlepin.insights.orgsync.db;
 
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+
+import java.util.List;
 
 /**
  * Repository for fetching the list of orgs to sync with rhsm-conduit.
  */
 public interface OrganizationRepository extends JpaRepository<Organization, String> {
-    /* intentionally left blank */
+    @Query(value = "select org_id from org_sync_list", nativeQuery = true)
+    List<String> getOrgIdList();
 }

--- a/src/main/java/org/candlepin/insights/task/TaskManager.java
+++ b/src/main/java/org/candlepin/insights/task/TaskManager.java
@@ -21,6 +21,7 @@
 package org.candlepin.insights.task;
 
 import org.candlepin.insights.orgsync.OrgListStrategy;
+import org.candlepin.insights.orgsync.OrgSyncProperties;
 import org.candlepin.insights.task.queue.TaskQueue;
 
 import org.quartz.JobExecutionException;
@@ -44,6 +45,9 @@ public class TaskManager {
 
     @Autowired
     TaskQueueProperties taskQueueProperties;
+
+    @Autowired
+    OrgSyncProperties orgSyncProperties;
 
     @Autowired
     OrgListStrategy orgListStrategy;
@@ -75,6 +79,14 @@ public class TaskManager {
 
         orgsToSync = orgListStrategy.getOrgsToSync();
 
+        if (orgSyncProperties.getLimit() != null) {
+            Integer size = orgsToSync.size();
+            Integer limit = orgSyncProperties.getLimit();
+            log.info("Fetched {} orgs to sync, but limiting to {}", size, limit);
+            if (limit < size) {
+                orgsToSync = orgsToSync.subList(0, limit);
+            }
+        }
         log.info("Starting inventory update for {} orgs", orgsToSync.size());
         orgsToSync.forEach(org -> {
             try {

--- a/src/test/java/org/candlepin/insights/orgsync/db/OrganizationRepositoryTest.java
+++ b/src/test/java/org/candlepin/insights/orgsync/db/OrganizationRepositoryTest.java
@@ -20,6 +20,8 @@
  */
 package org.candlepin.insights.orgsync.db;
 
+import static org.hamcrest.MatcherAssert.*;
+import static org.hamcrest.Matchers.*;
 import static org.junit.jupiter.api.Assertions.*;
 
 import org.junit.jupiter.api.Test;
@@ -43,6 +45,16 @@ class OrganizationRepositoryTest {
     void testSave() {
         Organization org = new Organization("1");
         assertNotNull(repository.saveAndFlush(org));
+    }
+
+    @Test
+    void testGetOrgIdMethod() {
+        Organization org1 = new Organization("1");
+        Organization org2 = new Organization("2");
+        assertNotNull(repository.saveAll(Arrays.asList(org1, org2)));
+        repository.flush();
+        assertEquals(2, repository.getOrgIdList().size());
+        assertThat(repository.getOrgIdList(), containsInAnyOrder("1", "2"));
     }
 
     @Test

--- a/src/test/java/org/candlepin/insights/task/TaskManagerTest.java
+++ b/src/test/java/org/candlepin/insights/task/TaskManagerTest.java
@@ -72,6 +72,18 @@ public class TaskManagerTest {
     }
 
     @Test
+    public void ensureOrgLimitIsEnforced() throws Exception {
+        List<String> expectedOrgs = Arrays.asList("org_a", "org_b", "org_c");
+        when(orgListStrategy.getOrgsToSync()).thenReturn(expectedOrgs);
+
+        manager.syncFullOrgList();
+
+        verify(queue, times(1)).enqueue(eq(createDescriptor("org_a")));
+        verify(queue, times(1)).enqueue(eq(createDescriptor("org_b")));
+        verify(queue, never()).enqueue(eq(createDescriptor("org_c")));
+    }
+
+    @Test
     public void ensureErrorOnUpdateContinuesWithoutFailure() throws Exception {
         List<String> expectedOrgs = Arrays.asList("org_a", "org_b");
         when(orgListStrategy.getOrgsToSync()).thenReturn(expectedOrgs);

--- a/src/test/resources/test.properties
+++ b/src/test/resources/test.properties
@@ -6,3 +6,5 @@ rhsm-conduit.inventory-service.useStub=true
 rhsm-conduit.datasource.platform=hsqldb
 rhsm-conduit.datasource.url=jdbc:hsqldb:mem:testdb
 rhsm-conduit.datasource.driver-class-name=org.hsqldb.jdbc.JDBCDriver
+
+rhsm-conduit.org-sync.limit = 2


### PR DESCRIPTION
New property is `rhsm-conduit.org-sync.limit`.

The DatabaseOrgListStrategy now avoids converting DB results into objects.