### PR TITLE
Bump max connections on X509ApiClientFactory

### DIFF
--- a/pinhead-client/src/main/java/org/candlepin/insights/pinhead/client/X509ApiClientFactory.java
+++ b/pinhead-client/src/main/java/org/candlepin/insights/pinhead/client/X509ApiClientFactory.java
@@ -106,6 +106,10 @@ public class X509ApiClientFactory implements FactoryBean<ApiClient>  {
 
         RequestConfig cookieConfig = RequestConfig.custom().setCookieSpec(CookieSpecs.IGNORE_COOKIES).build();
         apacheBuilder.setDefaultRequestConfig(cookieConfig);
+        // Bump the max connections so that our task processors do not
+        // block waiting to connect to Pinhead.
+        apacheBuilder.setMaxConnPerRoute(Integer.MAX_VALUE);
+        apacheBuilder.setMaxConnTotal(Integer.MAX_VALUE);
         HttpClient httpClient = apacheBuilder.build();
 
         // We've now constructed a basic Apache HttpClient.  Now we wire that in to RestEasy.  There is a


### PR DESCRIPTION
This was required since by default only a single connection
was allowed per path. This was causing the kafka processing
threads to make serial requests to the pinhead API causing a
significant bottleneck.