### PR TITLE
Handle remaining feed pages as separate tasks

### DIFF
--- a/api/rhsm-conduit-api-spec.yaml
+++ b/api/rhsm-conduit-api-spec.yaml
@@ -33,6 +33,12 @@ paths:
       operationId: getInventoryForOrg
       tags:
         - inventory
+      parameters:
+        - name: offset
+          in: query
+          schema:
+            type: string
+          description: pinhead pagination offset
       responses:
         '200':
           description: 'The request for inventory data was successful.'

--- a/pinhead-client/src/main/java/org/candlepin/insights/pinhead/client/StubPinheadApi.java
+++ b/pinhead-client/src/main/java/org/candlepin/insights/pinhead/client/StubPinheadApi.java
@@ -23,6 +23,8 @@ package org.candlepin.insights.pinhead.client;
 import org.candlepin.insights.pinhead.client.model.Consumer;
 import org.candlepin.insights.pinhead.client.model.InstalledProducts;
 import org.candlepin.insights.pinhead.client.model.OrgInventory;
+import org.candlepin.insights.pinhead.client.model.Pagination;
+import org.candlepin.insights.pinhead.client.model.Status;
 import org.candlepin.insights.pinhead.client.resources.PinheadApi;
 
 import org.slf4j.Logger;
@@ -66,8 +68,13 @@ public class StubPinheadApi extends PinheadApi {
         consumer2.setAccountNumber("ACCOUNT_1");
         consumer2.getFacts().put("network.fqdn", "host2.test.com");
 
-        inventory.getFeeds().add(consumer1);
-        inventory.getFeeds().add(consumer2);
+        if (offset == null) {
+            inventory.getFeeds().add(consumer1);
+            inventory.status(new Status().pagination(new Pagination().nextOffset("next-offset")));
+        }
+        else {
+            inventory.getFeeds().add(consumer2);
+        }
         log.info("Returning canned pinhead response: {}", inventory);
         return inventory;
     }

--- a/src/main/java/org/candlepin/insights/exception/MissingAccountNumberException.java
+++ b/src/main/java/org/candlepin/insights/exception/MissingAccountNumberException.java
@@ -1,0 +1,28 @@
+/*
+ * Copyright (c) 2009 - 2019 Red Hat, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ *
+ * Red Hat trademarks are not licensed under GPLv3. No permission is
+ * granted to use or replicate Red Hat trademarks that are incorporated
+ * in this software or its documentation.
+ */
+package org.candlepin.insights.exception;
+
+/**
+ * Exception thrown when an org does not have an account number.
+ */
+public class MissingAccountNumberException extends Exception {
+    /* intentionally empty */
+}

--- a/src/main/java/org/candlepin/insights/task/TaskDescriptor.java
+++ b/src/main/java/org/candlepin/insights/task/TaskDescriptor.java
@@ -140,7 +140,9 @@ public class TaskDescriptor {
         }
 
         public TaskDescriptorBuilder setArg(String name, String value) {
-            this.args.put(name, value);
+            if (value != null) {
+                this.args.put(name, value);
+            }
             return this;
         }
 

--- a/src/main/java/org/candlepin/insights/task/TaskFactory.java
+++ b/src/main/java/org/candlepin/insights/task/TaskFactory.java
@@ -47,7 +47,8 @@ public class TaskFactory {
      */
     public Task build(TaskDescriptor taskDescriptor) {
         if (TaskType.UPDATE_ORG_INVENTORY.equals(taskDescriptor.getTaskType())) {
-            return new UpdateOrgInventoryTask(inventoryController, taskDescriptor.getArg("org_id"));
+            return new UpdateOrgInventoryTask(inventoryController, taskDescriptor.getArg("org_id"),
+                taskDescriptor.getArg("offset"));
         }
         throw new IllegalArgumentException("Could not build task. Unknown task type: " +
             taskDescriptor.getTaskType());

--- a/src/main/java/org/candlepin/insights/task/TaskManager.java
+++ b/src/main/java/org/candlepin/insights/task/TaskManager.java
@@ -62,9 +62,21 @@ public class TaskManager {
      */
     @SuppressWarnings("indentation")
     public void updateOrgInventory(String orgId) {
+        updateOrgInventory(orgId, null);
+    }
+
+    /**
+     * Initiates a task that will update the inventory of the specified organization's ID.
+     *
+     * @param orgId the ID of the org in which to update.
+     * @param offset the offset to start at
+     */
+    @SuppressWarnings("indentation")
+    public void updateOrgInventory(String orgId, String offset) {
         queue.enqueue(
             TaskDescriptor.builder(TaskType.UPDATE_ORG_INVENTORY, taskQueueProperties.getTaskGroup())
                 .setArg("org_id", orgId)
+                .setArg("offset", offset)
                 .build()
         );
     }

--- a/src/main/java/org/candlepin/insights/task/TaskQueueConfiguration.java
+++ b/src/main/java/org/candlepin/insights/task/TaskQueueConfiguration.java
@@ -20,8 +20,8 @@
  */
 package org.candlepin.insights.task;
 
+import org.candlepin.insights.task.queue.ExecutorTaskProcessor;
 import org.candlepin.insights.task.queue.ExecutorTaskQueue;
-import org.candlepin.insights.task.queue.TaskQueue;
 
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -65,11 +65,19 @@ public class TaskQueueConfiguration {
     @Bean
     @ConditionalOnProperty(prefix = "rhsm-conduit.tasks", name = "queue", havingValue = "in-memory",
         matchIfMissing = true)
-    TaskQueue inMemoryQueue(TaskFactory taskFactory) {
+    ExecutorTaskQueue inMemoryQueue() {
         log.info("Configuring an in-memory task queue.");
-        return new ExecutorTaskQueue(
+        return new ExecutorTaskQueue();
+    }
+
+    @Bean
+    @ConditionalOnProperty(prefix = "rhsm-conduit.tasks", name = "queue", havingValue = "in-memory",
+        matchIfMissing = true)
+    ExecutorTaskProcessor inMemoryQueueProcessor(ExecutorTaskQueue queue, TaskFactory taskFactory) {
+        return new ExecutorTaskProcessor(
             Executors.newFixedThreadPool(taskQueueProperties().getExecutorTaskQueueThreadLimit()),
-            taskFactory
+            taskFactory,
+            queue
         );
     }
 

--- a/src/main/java/org/candlepin/insights/task/queue/ExecutorTaskProcessor.java
+++ b/src/main/java/org/candlepin/insights/task/queue/ExecutorTaskProcessor.java
@@ -1,0 +1,103 @@
+/*
+ * Copyright (c) 2009 - 2019 Red Hat, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ *
+ * Red Hat trademarks are not licensed under GPLv3. No permission is
+ * granted to use or replicate Red Hat trademarks that are incorporated
+ * in this software or its documentation.
+ */
+package org.candlepin.insights.task.queue;
+
+import org.candlepin.insights.task.TaskDescriptor;
+import org.candlepin.insights.task.TaskExecutionException;
+import org.candlepin.insights.task.TaskFactory;
+import org.candlepin.insights.task.TaskWorker;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.util.Optional;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.TimeUnit;
+
+/**
+ * Processor that is responsible for running queued tasks.
+ *
+ * Uses a separate thread to convert TaskDescriptors into actual tasks.
+ *
+ * @see ExecutorTaskQueue
+ */
+public class ExecutorTaskProcessor {
+    private static final Logger log = LoggerFactory.getLogger(ExecutorTaskProcessor.class);
+
+    private final ExecutorService executor;
+    private final ExecutorTaskQueue queue;
+    private final TaskFactory taskFactory;
+    private final Thread thread;
+
+    public ExecutorTaskProcessor(ExecutorService executor, TaskFactory taskFactory,
+        ExecutorTaskQueue queue) {
+        this.executor = executor;
+        this.taskFactory = taskFactory;
+        this.queue = queue;
+        this.thread = new Thread(this::run);
+        this.thread.start();
+    }
+
+    private void processTask(TaskDescriptor taskDescriptor) {
+        TaskWorker worker = new TaskWorker(taskFactory);
+        try {
+            worker.executeTask(taskDescriptor);
+        }
+        catch (TaskExecutionException e) {
+            log.error("An error occurred running a task.", e);
+        }
+    }
+
+    /**
+     * Shut down the associated executor gracefully, and wait for any pending tasks to complete.
+     *
+     * Used mainly for testing.
+     *
+     * @param timeout the maximum time to wait
+     * @param timeUnit the time unit of the timeout argument
+     * @throws InterruptedException
+     */
+    public void shutdown(long timeout, TimeUnit timeUnit) throws InterruptedException {
+        this.queue.shutdown();
+        this.thread.join();
+        this.executor.shutdown();
+        this.executor.awaitTermination(timeout, timeUnit);
+    }
+
+    private void run() {
+        log.info("Starting in-memory task processor");
+        while (true) {
+            try {
+                Optional<TaskDescriptor> task = queue.take();
+                if (task.isPresent()) {
+                    this.executor.execute(() -> this.processTask(task.get()));
+                }
+                else {
+                    log.info("Stopping in-memory task processor");
+                    break;
+                }
+            }
+            catch (InterruptedException e) {
+                Thread.currentThread().interrupt();
+            }
+        }
+    }
+}

--- a/src/main/java/org/candlepin/insights/task/tasks/UpdateOrgInventoryTask.java
+++ b/src/main/java/org/candlepin/insights/task/tasks/UpdateOrgInventoryTask.java
@@ -21,6 +21,8 @@
 package org.candlepin.insights.task.tasks;
 
 import org.candlepin.insights.controller.InventoryController;
+import org.candlepin.insights.exception.MissingAccountNumberException;
+import org.candlepin.insights.pinhead.client.ApiException;
 import org.candlepin.insights.task.Task;
 
 import org.slf4j.Logger;
@@ -36,16 +38,26 @@ public class UpdateOrgInventoryTask implements Task {
     private static Logger log = LoggerFactory.getLogger(UpdateOrgInventoryTask.class);
 
     private String orgId;
+    private String offset;
     private InventoryController controller;
 
-    public UpdateOrgInventoryTask(InventoryController controller, String orgId) {
+    public UpdateOrgInventoryTask(InventoryController controller, String orgId, String offset) {
         this.orgId = orgId;
+        this.offset = offset;
         this.controller = controller;
     }
 
     @Override
     public void execute() {
-        log.info("Updating inventory for org: {}", orgId);
-        controller.updateInventoryForOrg(orgId);
+        log.info("Updating inventory for org {} with offset {}", orgId, offset);
+        try {
+            controller.updateInventoryForOrg(orgId, offset);
+        }
+        catch (MissingAccountNumberException e) {
+            log.warn("Org {} is missing account number", orgId);
+        }
+        catch (ApiException e) {
+            log.error("Exception calling pinhead", e);
+        }
     }
 }

--- a/src/test/java/org/candlepin/insights/resource/InventoriesResourceTest.java
+++ b/src/test/java/org/candlepin/insights/resource/InventoriesResourceTest.java
@@ -21,6 +21,8 @@
 package org.candlepin.insights.resource;
 
 import org.candlepin.insights.controller.InventoryController;
+import org.candlepin.insights.exception.MissingAccountNumberException;
+import org.candlepin.insights.pinhead.client.ApiException;
 import org.candlepin.insights.task.TaskManager;
 
 import org.junit.jupiter.api.Test;
@@ -38,10 +40,11 @@ class InventoriesResourceTest {
     TaskManager manager;
 
     @Test
-    void testGetInventoryCallsInventoryController() {
+    void testGetInventoryCallsInventoryController()
+        throws MissingAccountNumberException, ApiException {
         InventoriesResource inventories = new InventoriesResource(controller, manager);
-        inventories.getInventoryForOrg("org-1234");
-        Mockito.verify(controller).getInventoryForOrg(Mockito.eq("org-1234"));
+        inventories.getInventoryForOrg("org-1234", null);
+        Mockito.verify(controller).getInventoryForOrg(Mockito.eq("org-1234"), Mockito.eq(null));
     }
 
     @Test

--- a/src/test/java/org/candlepin/insights/task/TaskManagerTest.java
+++ b/src/test/java/org/candlepin/insights/task/TaskManagerTest.java
@@ -24,6 +24,7 @@ import static org.junit.jupiter.api.Assertions.*;
 import static org.mockito.BDDMockito.*;
 
 import org.candlepin.insights.orgsync.db.DatabaseOrgList;
+import org.candlepin.insights.task.queue.ExecutorTaskProcessor;
 import org.candlepin.insights.task.queue.TaskQueue;
 
 import org.junit.jupiter.api.Test;
@@ -41,6 +42,9 @@ public class TaskManagerTest {
     @MockBean
     private TaskQueue queue;
 
+    @MockBean
+    private ExecutorTaskProcessor processor;
+
     @Autowired
     private TaskManager manager;
 
@@ -53,7 +57,7 @@ public class TaskManagerTest {
     @Test
     public void testUpdateOrgInventory() {
         String expectedOrg = "my-org";
-        manager.updateOrgInventory(expectedOrg);
+        manager.updateOrgInventory(expectedOrg, null);
 
         verify(queue).enqueue(eq(createDescriptor(expectedOrg)));
     }

--- a/src/test/java/org/candlepin/insights/task/queue/ExecutorTaskQueueTest.java
+++ b/src/test/java/org/candlepin/insights/task/queue/ExecutorTaskQueueTest.java
@@ -43,7 +43,9 @@ public class ExecutorTaskQueueTest {
 
     @Test
     public void ensureTaskIsExecutedPriorToShutdown() throws InterruptedException {
-        ExecutorTaskQueue queue = new ExecutorTaskQueue(Executors.newCachedThreadPool(), taskFactory);
+        ExecutorTaskQueue queue = new ExecutorTaskQueue();
+        ExecutorTaskProcessor processor = new ExecutorTaskProcessor(Executors.newCachedThreadPool(),
+            taskFactory, queue);
         TaskDescriptor expectedTaskDesc =
             TaskDescriptor.builder(TaskType.UPDATE_ORG_INVENTORY, "my-group").build();
         final AtomicBoolean done = new AtomicBoolean();
@@ -51,27 +53,29 @@ public class ExecutorTaskQueueTest {
             done.set(true);
         });
         queue.enqueue(expectedTaskDesc);
-        queue.shutdown(2000, TimeUnit.MILLISECONDS);
+        processor.shutdown(2000, TimeUnit.MILLISECONDS);
         assertTrue(done.get());
     }
 
     @Test
     public void verifyNoExceptionWhenTaskFails() throws InterruptedException {
         AtomicBoolean failed = new AtomicBoolean();
-        ExecutorTaskQueue queue = new ExecutorTaskQueue(Executors.newCachedThreadPool((runnable) -> {
-            Thread thread = new Thread(runnable);
-            thread.setUncaughtExceptionHandler((_thread, throwable) -> {
-                failed.set(true);
-            });
-            return thread;
-        }), taskFactory);
+        ExecutorTaskQueue queue = new ExecutorTaskQueue();
+        ExecutorTaskProcessor processor =
+            new ExecutorTaskProcessor(Executors.newCachedThreadPool((runnable) -> {
+                Thread thread = new Thread(runnable);
+                thread.setUncaughtExceptionHandler((_thread, throwable) -> {
+                    failed.set(true);
+                });
+                return thread;
+            }), taskFactory, queue);
         TaskDescriptor expectedTaskDesc =
             TaskDescriptor.builder(TaskType.UPDATE_ORG_INVENTORY, "my-group").build();
         Mockito.when(taskFactory.build(Mockito.any())).thenReturn(() -> {
             throw new RuntimeException("Error!");
         });
         queue.enqueue(expectedTaskDesc);
-        queue.shutdown(2000, TimeUnit.MILLISECONDS);
+        processor.shutdown(2000, TimeUnit.MILLISECONDS);
         assertFalse(failed.get());
     }
 }

--- a/src/test/java/org/candlepin/insights/task/queue/kafka/KafkaTaskQueueTester.java
+++ b/src/test/java/org/candlepin/insights/task/queue/kafka/KafkaTaskQueueTester.java
@@ -64,7 +64,7 @@ public class KafkaTaskQueueTester {
 
         when(factory.build(eq(taskDescriptor))).thenReturn(cdt);
 
-        manager.updateOrgInventory(orgId);
+        manager.updateOrgInventory(orgId, null);
 
         // Wait a max of 5 seconds for the task to be executed
         latch.await(5L, TimeUnit.SECONDS);

--- a/src/test/java/org/candlepin/insights/task/tasks/UpdateOrgInventoryTaskTest.java
+++ b/src/test/java/org/candlepin/insights/task/tasks/UpdateOrgInventoryTaskTest.java
@@ -23,6 +23,8 @@ package org.candlepin.insights.task.tasks;
 import static org.mockito.BDDMockito.*;
 
 import org.candlepin.insights.controller.InventoryController;
+import org.candlepin.insights.exception.MissingAccountNumberException;
+import org.candlepin.insights.pinhead.client.ApiException;
 
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -37,10 +39,10 @@ public class UpdateOrgInventoryTaskTest {
     private InventoryController controller;
 
     @Test
-    public void testExecute() {
+    public void testExecute() throws MissingAccountNumberException, ApiException {
         String expectedOrg = "my-org";
-        UpdateOrgInventoryTask task = new UpdateOrgInventoryTask(controller, expectedOrg);
+        UpdateOrgInventoryTask task = new UpdateOrgInventoryTask(controller, expectedOrg, null);
         task.execute();
-        Mockito.verify(controller).updateInventoryForOrg(eq(expectedOrg));
+        Mockito.verify(controller).updateInventoryForOrg(eq(expectedOrg), eq(null));
     }
 }


### PR DESCRIPTION
To test, use the following config in `config/application.properties`:

```
rhsm-conduit.pinhead.use_stub=true
rhsm-conduit.pinhead.batchSize=1
rhsm-conduit.inventory-service.use-stub=true
```

I modified the pinhead stub to produce two pages instead of one. You can verify the behavior with the above config, by either waiting or hitting the API through swagger-ui.

I had to modify the in-memory task queue implementation, because it was causing a circular dependency (introducing a need for the worker to be able to queue up tasks made a circular dep on the producer/consumer, so they needed to be separated).