### PR TITLE
1817067: Normalize insights ID

### DIFF
--- a/insights-inventory-client/src/main/java/org/candlepin/insights/inventory/client/InventoryServiceProperties.java
+++ b/insights-inventory-client/src/main/java/org/candlepin/insights/inventory/client/InventoryServiceProperties.java
@@ -36,6 +36,7 @@ public class InventoryServiceProperties {
     private String kafkaHostIngressTopic = "platform.inventory.host-ingress";
     private int apiHostUpdateBatchSize = 50;
     private int staleHostOffsetInDays = 0;
+    private boolean addUuidHyphens = false;
 
     @DurationUnit(ChronoUnit.HOURS)
     private Duration hostLastSyncThreshold = Duration.ofHours(24);
@@ -102,5 +103,13 @@ public class InventoryServiceProperties {
 
     public void setHostLastSyncThreshold(Duration hostLastSyncThreshold) {
         this.hostLastSyncThreshold = hostLastSyncThreshold;
+    }
+
+    public boolean isAddUuidHyphens() {
+        return addUuidHyphens;
+    }
+
+    public void setAddUuidHyphens(boolean addUuidHyphens) {
+        this.addUuidHyphens = addUuidHyphens;
     }
 }

--- a/src/main/resources/rhsm-conduit.properties
+++ b/src/main/resources/rhsm-conduit.properties
@@ -20,6 +20,7 @@ rhsm-conduit.pinhead.requestBatchSize=1000
 # The API key configured by the inventory service.
 rhsm-conduit.inventory-service.apiKey=changeit
 #rhsm-conduit.inventory-service.host-last-sync-threshold=24h
+#rhsm-conduit.inventory-service.add-uuid-hyphens=false
 
 # Inventory service kafka configuration
 #rhsm-conduit.inventory-service.enableKafka=true


### PR DESCRIPTION
Normalize by trimming, and adding in hyphens if they are missing.
    
The hypen addition is gated by a config property: `rhsm-conduit.inventory-service.add-uuid-hyphens`, and turned off by default, as we need to confirm that HBI deduplicates properly with it turned on.