### PR TITLE
Add metrics for host, org, and message rates

### DIFF
--- a/src/main/java/org/candlepin/insights/inventory/InventoryServiceConfiguration.java
+++ b/src/main/java/org/candlepin/insights/inventory/InventoryServiceConfiguration.java
@@ -40,6 +40,8 @@ import org.springframework.kafka.annotation.EnableKafka;
 import org.springframework.kafka.core.KafkaTemplate;
 import org.springframework.kafka.core.ProducerFactory;
 
+import io.micrometer.core.instrument.MeterRegistry;
+
 /**
  * Configures all beans required to connect to the inventory service's Kafka instance.
  */
@@ -116,7 +118,8 @@ public class InventoryServiceConfiguration {
     public InventoryService kafkaInventoryService(
         @Qualifier("inventoryServiceKafkaProducerTemplate")
         KafkaTemplate<String, HostOperationMessage> producer,
-        InventoryServiceProperties serviceProperties) {
-        return new KafkaEnabledInventoryService(serviceProperties, producer);
+        InventoryServiceProperties serviceProperties,
+        MeterRegistry meterRegistry) {
+        return new KafkaEnabledInventoryService(serviceProperties, producer, meterRegistry);
     }
 }

--- a/src/main/java/org/candlepin/insights/inventory/kafka/KafkaEnabledInventoryService.java
+++ b/src/main/java/org/candlepin/insights/inventory/kafka/KafkaEnabledInventoryService.java
@@ -24,9 +24,14 @@ import org.candlepin.insights.inventory.ConduitFacts;
 import org.candlepin.insights.inventory.InventoryService;
 import org.candlepin.insights.inventory.client.InventoryServiceProperties;
 
+import org.apache.kafka.clients.producer.RecordMetadata;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.kafka.core.KafkaTemplate;
+import org.springframework.kafka.support.SendResult;
+
+import io.micrometer.core.instrument.Counter;
+import io.micrometer.core.instrument.MeterRegistry;
 
 import java.time.OffsetDateTime;
 import java.util.Collections;
@@ -43,13 +48,19 @@ public class KafkaEnabledInventoryService extends InventoryService {
 
     private final KafkaTemplate<String, HostOperationMessage> producer;
     private final String hostIngressTopic;
+    private final Counter sentMessageCounter;
+    private final Counter failedMessageCounter;
+    private final Counter messageSizeCounter;
 
     public KafkaEnabledInventoryService(InventoryServiceProperties serviceProperties,
-        KafkaTemplate<String, HostOperationMessage> producer) {
+        KafkaTemplate<String, HostOperationMessage> producer, MeterRegistry meterRegistry) {
         // Flush updates as soon as they get scheduled.
         super(serviceProperties, 1);
         this.producer = producer;
         this.hostIngressTopic = serviceProperties.getKafkaHostIngressTopic();
+        this.sentMessageCounter = meterRegistry.counter("rhsm-conduit.send.inventory-message");
+        this.failedMessageCounter = meterRegistry.counter("rhsm.conduit.send.inventory-message.failed");
+        this.messageSizeCounter = meterRegistry.counter("rhsm-conduit.inventory-message.size.bytes");
     }
 
     @Override
@@ -76,12 +87,25 @@ public class KafkaEnabledInventoryService extends InventoryService {
             try {
                 log.debug("Sending host inventory message: {}:{}:{}", factSet.getAccountNumber(),
                     factSet.getOrgId(), factSet.getSubscriptionManagerId());
-                producer.send(hostIngressTopic, new CreateUpdateHostMessage(createHost(factSet, now)));
+                producer.send(hostIngressTopic, new CreateUpdateHostMessage(createHost(factSet, now)))
+                    .addCallback(this::recordSuccess, this::recordFailure);
             }
             catch (Exception e) {
-                log.error("Unable to send host create/update message.", e);
+                recordFailure(e);
             }
         }
+    }
+
+    private void recordFailure(Throwable throwable) {
+        log.error("Unable to send host create/update message.", throwable);
+        failedMessageCounter.increment();
+    }
+
+    private void recordSuccess(SendResult<String, HostOperationMessage> result) {
+        sentMessageCounter.increment();
+        RecordMetadata metadata = result.getRecordMetadata();
+        double messageSize = (double) metadata.serializedKeySize() + metadata.serializedValueSize();
+        messageSizeCounter.increment(messageSize);
     }
 
 }

--- a/src/main/java/org/candlepin/insights/inventory/kafka/KafkaEnabledInventoryService.java
+++ b/src/main/java/org/candlepin/insights/inventory/kafka/KafkaEnabledInventoryService.java
@@ -52,6 +52,7 @@ public class KafkaEnabledInventoryService extends InventoryService {
     private final Counter failedMessageCounter;
     private final Counter messageSizeCounter;
 
+    @SuppressWarnings("java:S3740")
     public KafkaEnabledInventoryService(InventoryServiceProperties serviceProperties,
         KafkaTemplate<String, HostOperationMessage> producer, MeterRegistry meterRegistry) {
         // Flush updates as soon as they get scheduled.
@@ -101,6 +102,7 @@ public class KafkaEnabledInventoryService extends InventoryService {
         failedMessageCounter.increment();
     }
 
+    @SuppressWarnings("java:S3740")
     private void recordSuccess(SendResult<String, HostOperationMessage> result) {
         sentMessageCounter.increment();
         RecordMetadata metadata = result.getRecordMetadata();


### PR DESCRIPTION
This adds the following metrics:

 - `rhsm-conduit.queue.next-page` - counter for number of times a new page is queued up
 - `rhsm-conduit.finalize.org` - counter for the number of times orgs finished syncing
 - `rhsm-conduit.transform.host` - time taken to transform a host
 - `rhsm-conduit.validate.host` - time taken to validate a host
 - `rhsm-conduit.send.inventory-message` - number of successful message sends to inventory
 - `rhsm.conduit.send.inventory-message.failed` - number of failed message sends to inventory
 - `rhsm-conduit.inventory-message.size.bytes` - size of messages emitted to inventory

To test, run kafka locally via `docker run --rm --net host landoop/fast-data-dev`, and use the following config:

```
rhsm-conduit.inventory-service.enableKafka=true
rhsm-conduit.inventory-service.kafka.bootstrap-servers=localhost:9092
```

Run with `./gradlew bootRun --args='--server.port=8111`

Note new metrics returned via `curl http://localhost:8111/actuator/prometheus | egrep '^rhsm_conduit' | sort`:

Note that the actual prometheus metrics have names that are a little different than the micrometer counterparts:

 - `[_-]` replaced with `_`
 - `_total` appended for counters
 - `_seconds_sum`, `_seconds_count` for timers

If desired you can also try stopping kafka and watching the failed messages count increase.