### PR TITLE
Limit http connections by default to 100

### DIFF
--- a/pinhead-client/src/main/java/org/candlepin/insights/pinhead/client/PinheadApiProperties.java
+++ b/pinhead-client/src/main/java/org/candlepin/insights/pinhead/client/PinheadApiProperties.java
@@ -114,4 +114,12 @@ public class PinheadApiProperties {
     public void setRequestBatchSize(int requestBatchSize) {
         this.requestBatchSize = requestBatchSize;
     }
+
+    public int getMaxConnections() {
+        return x509Config.getMaxConnections();
+    }
+
+    public void setMaxConnections(int maxConnections) {
+        x509Config.setMaxConnections(maxConnections);
+    }
 }

--- a/pinhead-client/src/main/java/org/candlepin/insights/pinhead/client/X509ApiClientFactory.java
+++ b/pinhead-client/src/main/java/org/candlepin/insights/pinhead/client/X509ApiClientFactory.java
@@ -108,8 +108,10 @@ public class X509ApiClientFactory implements FactoryBean<ApiClient>  {
         apacheBuilder.setDefaultRequestConfig(cookieConfig);
         // Bump the max connections so that our task processors do not
         // block waiting to connect to Pinhead.
-        apacheBuilder.setMaxConnPerRoute(Integer.MAX_VALUE);
-        apacheBuilder.setMaxConnTotal(Integer.MAX_VALUE);
+
+        // note that these are essentially the same, since we're only hitting a single hostname
+        apacheBuilder.setMaxConnPerRoute(x509Config.getMaxConnections());
+        apacheBuilder.setMaxConnTotal(x509Config.getMaxConnections());
         HttpClient httpClient = apacheBuilder.build();
 
         // We've now constructed a basic Apache HttpClient.  Now we wire that in to RestEasy.  There is a

--- a/pinhead-client/src/main/java/org/candlepin/insights/pinhead/client/X509ApiClientFactoryConfiguration.java
+++ b/pinhead-client/src/main/java/org/candlepin/insights/pinhead/client/X509ApiClientFactoryConfiguration.java
@@ -39,6 +39,7 @@ public class X509ApiClientFactoryConfiguration {
     private String keystoreFile;
     private String truststoreFile;
     private String truststorePassword;
+    private int maxConnections = 100;
 
     private HostnameVerifier hostnameVerifier = new DefaultHostnameVerifier();
 
@@ -117,4 +118,11 @@ public class X509ApiClientFactoryConfiguration {
             truststoreFile, keystoreFile);
     }
 
+    public int getMaxConnections() {
+        return maxConnections;
+    }
+
+    public void setMaxConnections(int maxConnections) {
+        this.maxConnections = maxConnections;
+    }
 }

--- a/src/main/resources/rhsm-conduit.properties
+++ b/src/main/resources/rhsm-conduit.properties
@@ -16,6 +16,7 @@ rhsm-conduit.org-sync.fileBasedOrgListStrategy.org-resource-location=classpath:e
 
 # Pinhead service default properties
 rhsm-conduit.pinhead.requestBatchSize=1000
+# rhsm-conduit.pinhead.maxConnections=100
 
 # The API key configured by the inventory service.
 rhsm-conduit.inventory-service.apiKey=changeit


### PR DESCRIPTION
Note that I looked to test that the connection limit is enforced, but
could not find a good way to do so in unit tests...