### PR TITLE
Move config to env vars

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,6 +73,12 @@ Build and run using the following line:
 ./gradlew assemble && java -jar build/libs/rhsm-conduit-1.0.0.jar
 ```
 
+Because setting up the Pinhead keystore can be difficult, consider starting with:
+
+```sh
+PINHEAD_USE_STUB=true ./gradlew bootRun
+```
+
 # Remote Deployment
 
 ## OpenShift Project Set Up
@@ -168,6 +174,45 @@ Both the health actuator and info actuator can be modified, expanded, or
 extended. Please see the
 [documentation](https://docs.spring.io/spring-boot/docs/current/reference/html/production-ready-endpoints.html)
 for a discussion of extension points.
+
+### Environment Variables
+
+* `PRETTY_PRINT_JSON`: configure Jackson to indent outputted JSON
+* `APP_NAME`: application name for URLs (default: rhsm-conduit)
+* `PATH_PREFIX`: path prefix in the URLs (default: api)
+* `TASK_QUEUE_TYPE`: `in-memory` or `kafka`
+* `ORG_SYNC_SCHEDULE`: cron schedule for syncing hosts
+* `ORG_SYNC_STRATEGY`: file-based or DB-based sync strategy
+* `ORG_SYNC_RESOURCE_LOCATION`: location of resource with org sync list (if using file-based sync strategy)
+* `PINHEAD_USE_STUB`: Use pinhead stub
+* `PINHEAD_URL`: Pinhead service URL
+* `PINHEAD_KEYSTORE`: path to keystore with client cert
+* `PINHEAD_KEYSTORE_PASSWORD`: pinhead client cert keystore password
+* `PINHEAD_BATCH_SIZE`: host sync batch size
+* `PINHEAD_MAX_CONNECTIONS`: maximum concurrent connections to pinhead
+* `INVENTORY_USE_STUB`: Use stubbed inventory REST API
+* `INVENTORY_API_KEY`: API key for inventory service
+* `INVENTORY_HOST_LAST_SYNC_THRESHOLD`: reject hosts that haven't checked in since this duration (e.g. 24h)
+* `INVENTORY_ENABLE_KAFKA`: whether kafka should be used (inventory API otherwise)
+* `INVENTORY_HOST_INGRESS_TOPIC`: kafka topic to emit host records
+* `INVENTORY_ADD_UUID_HYPHENS`: whether to add missing UUID hyphens to the Insights ID
+* `DATABASE_HOST`: DB host
+* `DATABASE_PORT`: DB port
+* `DATABASE_DATABASE`: DB database
+* `DATABASE_USERNAME`: DB username
+* `DATABASE_PASSWORD`: DB password
+* `KAFKA_TASK_GROUP`: kafka task group
+* `KAFKA_CONSUMER_MAX_POLL_INTERVAL_MS`: kafka max poll interval in milliseconds
+* `KAFKA_MESSAGE_THREADS`: number of consumer threads
+* `KAFKA_BOOTSTRAP_HOST`: kafka bootstrap host
+* `KAFKA_BOOTSTRAP_PORT`: kafka boostrap port
+* `KAFKA_CONSUMER_RECONNECT_BACKOFF_MS`: kafka consumer reconnect backoff in milliseconds
+* `KAFKA_CONSUMER_RECONNECT_BACKOFF_MAX_MS`: kafka consumer reconnect max backoff in milliseconds
+* `KAFKA_API_RECONNECT_TIMEOUT_MS`: kafka connection timeout
+* `KAFKA_SCHEMA_REGISTRY_SCHEME`: avro schema server scheme (http or https)
+* `KAFKA_SCHEMA_REGISTRY_HOST`: kafka schema server host
+* `KAFKA_SCHEMA_REGISTRY_PORT`: kafka schema server port
+* `KAFKA_AUTO_REGISTER_SCHEMAS`: enable auto registration of schemas
 
 ## Release Notes
 

--- a/pinhead-client/src/main/java/org/candlepin/insights/pinhead/client/X509ApiClientFactoryConfiguration.java
+++ b/pinhead-client/src/main/java/org/candlepin/insights/pinhead/client/X509ApiClientFactoryConfiguration.java
@@ -106,7 +106,7 @@ public class X509ApiClientFactoryConfiguration {
     }
 
     public boolean usesClientAuth() {
-        return (getKeystoreFile() != null && getKeystorePassword() != null);
+        return (getKeystoreFile() != null && !getKeystoreFile().isEmpty() && getKeystorePassword() != null);
     }
 
     public boolean usesDefaultTruststore() {

--- a/src/main/java/org/candlepin/insights/task/queue/kafka/KafkaConfigurator.java
+++ b/src/main/java/org/candlepin/insights/task/queue/kafka/KafkaConfigurator.java
@@ -107,6 +107,7 @@ public class KafkaConfigurator {
     }
 
     private boolean bypassSchemaRegistry(Map<String, Object> config) {
-        return !config.containsKey(AbstractKafkaAvroSerDeConfig.SCHEMA_REGISTRY_URL_CONFIG);
+        return ((String) config.getOrDefault(AbstractKafkaAvroSerDeConfig.SCHEMA_REGISTRY_URL_CONFIG, ""))
+            .isEmpty();
     }
 }

--- a/src/main/resources/rhsm-conduit.properties
+++ b/src/main/resources/rhsm-conduit.properties
@@ -3,69 +3,73 @@
 # classes annotated with @ConfigurationProperties will ingest them.
 
 # Pretty print the response JSON returned by the API.
-rhsm-conduit.prettyPrintJson=false
+rhsm-conduit.prettyPrintJson=${PRETTY_PRINT_JSON:false}
 
 # We're keeping the context-path as "/" so that the actuators we use for OKD liveness/readiness probes have a
 # fixed path.  The actual conduit resources will be configured to hang off of the path below.
-rhsm-conduit.package_uri_mappings.org.candlepin.insights=${PATH_PREFIX:/r/insights/platform}/${APP_NAME:rhsm-conduit}/v1
-rhsm-conduit.org-sync.schedule=0 */2 * * * ?
-rhsm-conduit.org-sync.strategy = fileBasedOrgListStrategy
+rhsm-conduit.package_uri_mappings.org.candlepin.insights=${PATH_PREFIX:api}/${APP_NAME:rhsm-conduit}/v1
+rhsm-conduit.org-sync.schedule=${ORG_SYNC_SCHEDULE:0 */2 * * * ?}
+rhsm-conduit.org-sync.strategy = ${ORG_SYNC_STRATEGY:fileBasedOrgListStrategy}
 
 # Use Spring Resource notation for this (e.g. "classpath:" or "file:")
-rhsm-conduit.org-sync.fileBasedOrgListStrategy.org-resource-location=classpath:empty-org-list.txt
+rhsm-conduit.org-sync.fileBasedOrgListStrategy.org-resource-location=${ORG_SYNC_RESOURCE_LOCATION:classpath:empty-org-list.txt}
 
 # Pinhead service default properties
-rhsm-conduit.pinhead.requestBatchSize=1000
-# rhsm-conduit.pinhead.maxConnections=100
+rhsm-conduit.pinhead.useStub=${PINHEAD_USE_STUB:false}
+rhsm-conduit.pinhead.url=${PINHEAD_URL:http://localhost:9090}
+rhsm-conduit.pinhead.keystore_file=${PINHEAD_KEYSTORE:}
+rhsm-conduit.pinhead.keystore_password=${PINHEAD_KEYSTORE_PASSWORD:changeit}
+rhsm-conduit.pinhead.requestBatchSize=${PINHEAD_BATCH_SIZE:1000}
+rhsm-conduit.pinhead.maxConnections=${PINHEAD_MAX_CONNECTIONS:100}
 
 # The API key configured by the inventory service.
-rhsm-conduit.inventory-service.apiKey=changeit
-#rhsm-conduit.inventory-service.host-last-sync-threshold=24h
-#rhsm-conduit.inventory-service.add-uuid-hyphens=false
+rhsm-conduit.inventory-service.useStub=${INVENTORY_USE_STUB:true}
+rhsm-conduit.inventory-service.apiKey=${INVENTORY_API_KEY:changeit}
+rhsm-conduit.inventory-service.host-last-sync-threshold=${INVENTORY_HOST_LAST_SYNC_THRESHOLD:24h}
+rhsm-conduit.inventory-service.add-uuid-hyphens=${INVENTORY_ADD_UUID_HYPHENS:false}
+# FIXME: misnamed, it's actually in hours
+rhsm-conduit.inventory-service.staleHostOffsetInDays=${INVENTORY_STALE_HOST_OFFSET_HOURS:48}
 
 # Inventory service kafka configuration
-#rhsm-conduit.inventory-service.enableKafka=true
-#rhsm-conduit.inventory-service.kafka.bootstrap-servers=localhost:9092
+rhsm-conduit.inventory-service.enableKafka=${INVENTORY_ENABLE_KAFKA:true}
+rhsm-conduit.inventory-service.kafka.bootstrap-servers=${KAFKA_BOOTSTRAP_HOST:localhost}:${KAFKA_BOOTSTRAP_PORT:9092}
+rhsm-conduit.inventory-service.kafkaHostIngressTopic=${INVENTORY_HOST_INGRESS_TOPIC:platform.inventory.host-ingress}
 
 # Default Quartz datasource.  Override by pulling in another rhsm-conduit.properties file via an
 # -Dspring.config.additional-location argument
 rhsm-conduit.datasource.platform=hsqldb
+rhsm-conduit.datasource.url=jdbc:hsqldb:mem:quartz
+rhsm-conduit.datasource.driver-class-name=org.hsqldb.jdbc.JDBCDriver
 
 #
 # kafka configuration
 #
 
-# Uncomment to enable Kafka integration
-#rhsm-conduit.tasks.queue=kafka
-#rhsm-conduit.tasks.task-group=rhsm-conduit-tasks
+rhsm-conduit.tasks.queue=${TASK_QUEUE_TYPE:in-memory}
+rhsm-conduit.tasks.task-group=${KAFKA_TASK_GROUP:platform.rhsm-conduit.tasks}
 
 # Required kafka defaults
 spring.kafka.consumer.properties.max.poll.records=1
-spring.kafka.consumer.properties.max.poll.interval.ms=1800000
+spring.kafka.consumer.properties.max.poll.interval.ms=${KAFKA_CONSUMER_MAX_POLL_INTERVAL_MS:1800000}
 
 # The number of threads that will be processing messages (should match
 # the number of partitions on the queue)
-#spring.kafka.listener.concurrency=1
-#spring.kafka.bootstrap-servers=localhost:9092
-#spring.kafka.consumer.properties.reconnect.backoff.ms=2000
-#spring.kafka.consumer.properties.reconnect.backoff.max.ms=10000
-#spring.kafka.consumer.properties.default.api.timeout.ms=480000
+spring.kafka.listener.concurrency=${KAFKA_MESSAGE_THREADS:1}
+spring.kafka.bootstrap-servers=${KAFKA_BOOTSTRAP_HOST:localhost}:${KAFKA_BOOTSTRAP_PORT:9092}
+spring.kafka.consumer.properties.reconnect.backoff.ms=${KAFKA_CONSUMER_RECONNECT_BACKOFF_MS:2000}
+spring.kafka.consumer.properties.reconnect.backoff.max.ms=${KAFKA_CONSUMER_RECONNECT_BACKOFF_MAX_MS:10000}
+spring.kafka.consumer.properties.default.api.timeout.ms=${KAFKA_API_RECONNECT_TIMEOUT_MS:480000}
 
 #
 # Schema Registry configuration
 #
 
-#spring.kafka.properties.schema.registry.url=http://localhost:8081
-#spring.kafka.properties.auto.register.schemas=false
+spring.kafka.properties.schema.registry.url=${KAFKA_SCHEMA_REGISTRY_SCHEME:http}://${KAFKA_SCHEMA_REGISTRY_HOST:localhost}:${KAFKA_SCHEMA_REGSITRY_PORT:8081}
+spring.kafka.properties.auto.register.schemas=${KAFKA_AUTO_REGISTER_SCHEMAS:true}
 
-# OrgConfig DB defaults - hsqldb
-rhsm-subscriptions.datasource.url=jdbc:hsqldb:mem:orgsyncdb
-rhsm-subscriptions.datasource.platform=hsqldb
-
-# OrgConfig DB (reference for when shared with rhsm-subscriptions)
-#rhsm-subscriptions.datasource.url=jdbc:postgresql://${POSTGRESQL_SERVICE_HOST:localhost}:\
-#  ${POSTGRESQL_SERVICE_PORT:5432}/${DATABASE_NAME:rhsm-subscriptions}
-#rhsm-subscriptions.datasource.username=${DATABASE_USER:rhsm-subscriptions}
-#rhsm-subscriptions.datasource.password=${DATABASE_PASSWORD:rhsm-subscriptions}
-#rhsm-subscriptions.datasource.driver-class-name=org.postgresql.Driver
-#rhsm-subscriptions.datasource.platform=postgresql
+# OrgConfig DB
+rhsm-subscriptions.datasource.url=jdbc:postgresql://${DATABASE_HOST:localhost}:${DATABASE_PORT:5432}/${DATABASE_DATABASE:rhsm-subscriptions}
+rhsm-subscriptions.datasource.username=${DATABASE_USERNAME:rhsm-subscriptions}
+rhsm-subscriptions.datasource.password=${DATABASE_PASSWORD:rhsm-subscriptions}
+rhsm-subscriptions.datasource.driver-class-name=org.postgresql.Driver
+rhsm-subscriptions.datasource.platform=postgresql

--- a/src/test/java/org/candlepin/insights/controller/InventoryControllerTest.java
+++ b/src/test/java/org/candlepin/insights/controller/InventoryControllerTest.java
@@ -46,6 +46,7 @@ import org.mockito.Mockito;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.test.context.TestPropertySource;
 
 import java.math.BigDecimal;
 import java.time.Duration;
@@ -57,6 +58,7 @@ import java.util.Map;
 import java.util.UUID;
 
 @SpringBootTest
+@TestPropertySource("classpath:/test.properties")
 public class InventoryControllerTest {
     @MockBean
     InventoryService inventoryService;

--- a/src/test/resources/api_client_test.properties
+++ b/src/test/resources/api_client_test.properties
@@ -1,3 +1,8 @@
 rhsm-conduit.version=TEST
+rhsm-conduit.inventory-service.useStub=false
 rhsm-conduit.inventory-service.url=https://localhost/api/hostinventory
 rhsm-conduit.inventory-service.apiKey=mysecret
+
+rhsm-subscriptions.datasource.platform=hsqldb
+rhsm-subscriptions.datasource.url=jdbc:hsqldb:mem:orgsyncdb
+rhsm-subscriptions.datasource.driver-class-name=org.hsqldb.jdbc.JDBCDriver

--- a/src/test/resources/kafka_schema_registry_test.properties
+++ b/src/test/resources/kafka_schema_registry_test.properties
@@ -17,3 +17,7 @@ spring.kafka.consumer.auto-offset-reset=earliest
 # Enable the schema registry (registry mock ignores the URL but it must be set
 # to enable registry checking).
 spring.kafka.properties.schema.registry.url=unused
+
+rhsm-subscriptions.datasource.platform=hsqldb
+rhsm-subscriptions.datasource.url=jdbc:hsqldb:mem:orgsyncdb
+rhsm-subscriptions.datasource.driver-class-name=org.hsqldb.jdbc.JDBCDriver

--- a/src/test/resources/kafka_test.properties
+++ b/src/test/resources/kafka_test.properties
@@ -13,3 +13,10 @@ spring.kafka.bootstrap-servers=${spring.embedded.kafka.brokers}
 # In tests, messages may be sent before the listener has been assigned the topic
 # so we ensure that when the listener comes online it starts from first message.
 spring.kafka.consumer.auto-offset-reset=earliest
+
+# override schema registry url to empty string to disable avro integration
+spring.kafka.properties.schema.registry.url=
+
+rhsm-subscriptions.datasource.platform=hsqldb
+rhsm-subscriptions.datasource.url=jdbc:hsqldb:mem:orgsyncdb
+rhsm-subscriptions.datasource.driver-class-name=org.hsqldb.jdbc.JDBCDriver

--- a/src/test/resources/test.properties
+++ b/src/test/resources/test.properties
@@ -7,4 +7,8 @@ rhsm-conduit.datasource.platform=hsqldb
 rhsm-conduit.datasource.url=jdbc:hsqldb:mem:testdb
 rhsm-conduit.datasource.driver-class-name=org.hsqldb.jdbc.JDBCDriver
 
+rhsm-subscriptions.datasource.platform=hsqldb
+rhsm-subscriptions.datasource.url=jdbc:hsqldb:mem:orgsyncdb
+rhsm-subscriptions.datasource.driver-class-name=org.hsqldb.jdbc.JDBCDriver
+
 rhsm-conduit.org-sync.limit = 2


### PR DESCRIPTION
I put all of the variables we currently had configured via deployment automation and a few we use regularly during development.

Configuration is still overrideable via properties files, so the current `spring.config.additional-location` approach should work,
until we move to just environment variables.

I changed empty/null checking in a couple places as needed, and also changed the quartz config to use hsql by default (fine for conduit and to be replaced soon with `@Scheduled`).

See README.md for documentation.