### PR TITLE
Add template for rhsm-conduit

### DIFF
--- a/README.md
+++ b/README.md
@@ -123,26 +123,17 @@ curl http://<your_route_address>/metrics
 First, log in to an openshift instance. Make sure the project has been
 set up (see previous section).
 
-```
-# add a template for deploying rhsm-conduit
-oc create -f openshift/template_rhsm-conduit.yaml
-oc new-app --template=rhsm-conduit  # deploy an instance of rhsm-conduit using the template
-```
+Prerequisite secrets:
 
-By default, the template deploys the master branch of rhsm-conduit. If
-it's more appropriate to deploy a different branch (e.g. production),
-then use:
+- `rhsm-db-rds`: DB connection info, having `db.host`, `db.port`, `db.user`, `db.password`, and `db.name` properties.
+- `pinhead`: secret with `keystore.jks` - keystore for HTTPS communication with Pinhead.
+- `tls`: having `keystore.password`, the password used for pinhead keystore.
+
+Adjust as desired:
 
 ```
-oc new-app --template=rhsm-conduit -p SOURCE_REPOSITORY_REF=production
-```
-
-If, for debugging on a local machine, for convenience, you need a route
-to test rhsm-conduit,
-
-```
-oc create -f openshift/template_rhsm-conduit-route.yaml
-oc new-app --template=rhsm-conduit-route
+oc apply -f templates/rhsm-conduit.yaml
+oc new-app --template=rhsm-conduit --param=KAFKA_BOOTSTRAP_HOST=localhost --param=PINHEAD_URL=https://localhost --param=KAFKA_SCHEMA_REGISTRY_HOST=localhost  # deploy an instance of rhsm-conduit using the template
 ```
 
 ## Deployment Notes

--- a/templates/rhsm-conduit.yaml
+++ b/templates/rhsm-conduit.yaml
@@ -1,0 +1,258 @@
+apiVersion: v1
+kind: Template
+labels:
+  app: rhsm-conduit
+  template: rhsm-conduit
+metadata:
+  annotations:
+    description: An insights inventory collector for the subscription management service.
+  name: rhsm-conduit
+
+parameters:
+  - name: KAFKA_BOOTSTRAP_HOST
+    required: true
+  - name: PINHEAD_URL
+    required: true
+  - name: KAFKA_SCHEMA_REGISTRY_HOST
+    required: true
+  - name: LOGGING_LEVEL_ROOT
+    value: WARN
+  - name: LOGGING_LEVEL
+    value: INFO
+  - name: KAFKA_MESSAGE_THREADS
+    value: '24'
+  - name: KAFKA_CONSUMER_MAX_POLL_INTERVAL_MS
+    value: '3600000'
+  - name: REPLICAS
+    value: '1'
+  - name: IMAGE_TAG
+    value: latest
+  - name: MEMORY_REQUEST
+    value: 100Mi
+  - name: MEMORY_LIMIT
+    value: 2Gi
+  - name: CPU_REQUEST
+    value: 200m
+  - name: CPU_LIMIT
+    value: '1'
+
+objects:
+- apiVersion: v1
+  kind: ConfigMap
+  metadata:
+    name: rhsm-conduit-config
+  data:
+    rhsm-conduit.properties: |-
+      # Place application related defaults here.  This file is loaded via the @PropertySource annotation on the
+      # ApplicationConfiguration class.  Prefix properties in this file appropriately (e.g. "rhsm-conduit") so the
+      # classes annotated with @ConfigurationProperties will ingest them.
+
+      # Pretty print the response JSON returned by the API.
+      rhsm-conduit.prettyPrintJson=${PRETTY_PRINT_JSON:false}
+
+      # We're keeping the context-path as "/" so that the actuators we use for OKD liveness/readiness probes have a
+      # fixed path.  The actual conduit resources will be configured to hang off of the path below.
+      rhsm-conduit.package_uri_mappings.org.candlepin.insights=${PATH_PREFIX:api}/${APP_NAME:rhsm-conduit}/v1
+      rhsm-conduit.org-sync.schedule=${ORG_SYNC_SCHEDULE:0 */2 * * * ?}
+      rhsm-conduit.org-sync.strategy = ${ORG_SYNC_STRATEGY:fileBasedOrgListStrategy}
+
+      # Use Spring Resource notation for this (e.g. "classpath:" or "file:")
+      rhsm-conduit.org-sync.fileBasedOrgListStrategy.org-resource-location=${ORG_SYNC_RESOURCE_LOCATION:classpath:empty-org-list.txt}
+
+      # Pinhead service default properties
+      rhsm-conduit.pinhead.useStub=${PINHEAD_USE_STUB:false}
+      rhsm-conduit.pinhead.url=${PINHEAD_URL:http://localhost:9090}
+      rhsm-conduit.pinhead.keystore_file=${PINHEAD_KEYSTORE:}
+      rhsm-conduit.pinhead.keystore_password=${PINHEAD_KEYSTORE_PASSWORD:changeit}
+      rhsm-conduit.pinhead.requestBatchSize=${PINHEAD_BATCH_SIZE:1000}
+      rhsm-conduit.pinhead.maxConnections=${PINHEAD_MAX_CONNECTIONS:100}
+
+      # The API key configured by the inventory service.
+      rhsm-conduit.inventory-service.useStub=${INVENTORY_USE_STUB:true}
+      rhsm-conduit.inventory-service.apiKey=${INVENTORY_API_KEY:changeit}
+      rhsm-conduit.inventory-service.host-last-sync-threshold=${INVENTORY_HOST_LAST_SYNC_THRESHOLD:24h}
+      rhsm-conduit.inventory-service.add-uuid-hyphens=${INVENTORY_ADD_UUID_HYPHENS:false}
+      # FIXME: misnamed, it's actually in hours
+      rhsm-conduit.inventory-service.staleHostOffsetInDays=${INVENTORY_STALE_HOST_OFFSET_HOURS:48}
+
+      # Inventory service kafka configuration
+      rhsm-conduit.inventory-service.enableKafka=${INVENTORY_ENABLE_KAFKA:true}
+      rhsm-conduit.inventory-service.kafka.bootstrap-servers=${KAFKA_BOOTSTRAP_HOST:localhost}:${KAFKA_BOOTSTRAP_PORT:9092}
+      rhsm-conduit.inventory-service.kafkaHostIngressTopic=${INVENTORY_HOST_INGRESS_TOPIC:platform.inventory.host-ingress}
+
+      # Default Quartz datasource.  Override by pulling in another rhsm-conduit.properties file via an
+      # -Dspring.config.additional-location argument
+      rhsm-conduit.datasource.platform=hsqldb
+      rhsm-conduit.datasource.url=jdbc:hsqldb:mem:quartz
+      rhsm-conduit.datasource.driver-class-name=org.hsqldb.jdbc.JDBCDriver
+
+      #
+      # kafka configuration
+      #
+
+      rhsm-conduit.tasks.queue=${TASK_QUEUE_TYPE:in-memory}
+      rhsm-conduit.tasks.task-group=${KAFKA_TASK_GROUP:platform.rhsm-conduit.tasks}
+
+      # Required kafka defaults
+      spring.kafka.consumer.properties.max.poll.records=1
+      spring.kafka.consumer.properties.max.poll.interval.ms=${KAFKA_CONSUMER_MAX_POLL_INTERVAL_MS:1800000}
+
+      # The number of threads that will be processing messages (should match
+      # the number of partitions on the queue)
+      spring.kafka.listener.concurrency=${KAFKA_MESSAGE_THREADS:1}
+      spring.kafka.bootstrap-servers=${KAFKA_BOOTSTRAP_HOST:localhost}:${KAFKA_BOOTSTRAP_PORT:9092}
+      spring.kafka.consumer.properties.reconnect.backoff.ms=${KAFKA_CONSUMER_RECONNECT_BACKOFF_MS:2000}
+      spring.kafka.consumer.properties.reconnect.backoff.max.ms=${KAFKA_CONSUMER_RECONNECT_BACKOFF_MAX_MS:10000}
+      spring.kafka.consumer.properties.default.api.timeout.ms=${KAFKA_API_RECONNECT_TIMEOUT_MS:480000}
+
+      #
+      # Schema Registry configuration
+      #
+
+      spring.kafka.properties.schema.registry.url=${KAFKA_SCHEMA_REGISTRY_SCHEME:http}://${KAFKA_SCHEMA_REGISTRY_HOST:localhost}:${KAFKA_SCHEMA_REGSITRY_PORT:8081}
+      spring.kafka.properties.auto.register.schemas=${KAFKA_AUTO_REGISTER_SCHEMAS:true}
+
+      # OrgConfig DB
+      rhsm-subscriptions.datasource.url=jdbc:postgresql://${DATABASE_HOST:localhost}:${DATABASE_PORT:5432}/${DATABASE_DATABASE:rhsm-subscriptions}
+      rhsm-subscriptions.datasource.username=${DATABASE_USERNAME:rhsm-subscriptions}
+      rhsm-subscriptions.datasource.password=${DATABASE_PASSWORD:rhsm-subscriptions}
+      rhsm-subscriptions.datasource.driver-class-name=org.postgresql.Driver
+      rhsm-subscriptions.datasource.platform=postgresql
+
+- apiVersion: v1
+  kind: DeploymentConfig
+  metadata:
+    name: rhsm-conduit
+  spec:
+    replicas: ${REPLICAS}
+    selector:
+      deploymentconfig: rhsm-conduit
+    strategy:
+      type: Rolling
+    template:
+      metadata:
+        labels:
+          deploymentconfig: rhsm-conduit
+        annotations:
+          prometheus.io/path: /actuator/prometheus
+          prometheus.io/port: '8080'
+          prometheus.io/scrape: 'true'
+      spec:
+        containers:
+          - image: quay.io/cloudservices/rhsm-conduit:${IMAGE_TAG}
+            name: rhsm-conduit
+            env:
+              - name: JAVA_OPTIONS
+                value: -Dspring.config.additional-location=file:/config/rhsm-conduit.properties
+              - name: JAVA_MAX_MEM_RATIO
+                value: '85'
+              - name: GC_MAX_METASPACE_SIZE
+                value: '256'
+              - name: LOGGING_LEVEL_ROOT
+                value: ${LOGGING_LEVEL_ROOT}
+              - name: LOGGING_LEVEL_ORG_CANDLEPIN
+                value: ${LOGGING_LEVEL}
+              - name: PINHEAD_URL
+                value: ${PINHEAD_URL}
+              - name: KAFKA_BOOTSTRAP_HOST
+                value: ${KAFKA_BOOTSTRAP_HOST}
+              - name: KAFKA_SCHEMA_REGISTRY_HOST
+                value: ${KAFKA_SCHEMA_REGISTRY_HOST}
+              - name: KAFKA_MESSAGE_THREADS
+                value: ${KAFKA_MESSAGE_THREADS}
+              - name: KAFKA_CONSUMER_MAX_POLL_INTERVAL_MS
+                value: ${KAFKA_CONSUMER_MAX_POLL_INTERVAL_MS}
+              - name: DATABASE_HOST
+                valueFrom:
+                  secretKeyRef:
+                    name: rhsm-db-rds
+                    key: db.host
+              - name: DATABASE_PORT
+                valueFrom:
+                  secretKeyRef:
+                    name: rhsm-db-rds
+                    key: db.port
+              - name: DATABASE_USERNAME
+                valueFrom:
+                  secretKeyRef:
+                    name: rhsm-db-rds
+                    key: db.user
+              - name: DATABASE_PASSWORD
+                valueFrom:
+                  secretKeyRef:
+                    name: rhsm-db-rds
+                    key: db.password
+              - name: DATABASE_DATABASE
+                valueFrom:
+                  secretKeyRef:
+                    name: rhsm-db-rds
+                    key: db.name
+              - name: PINHEAD_KEYSTORE_PASSWORD
+                valueFrom:
+                  secretKeyRef:
+                    name: tls
+                    key: keystore.password
+              - name: PINHEAD_KEYSTORE
+                value: /pinhead/keystore.jks
+            livenessProbe:
+              failureThreshold: 3
+              httpGet:
+                path: /actuator/health
+                port: 8080
+                scheme: HTTP
+              initialDelaySeconds: 45
+              periodSeconds: 20
+              successThreshold: 1
+              timeoutSeconds: 10
+            readinessProbe:
+              failureThreshold: 3
+              httpGet:
+                path: /actuator/health
+                port: 8080
+                scheme: HTTP
+              initialDelaySeconds: 45
+              periodSeconds: 20
+              successThreshold: 1
+              timeoutSeconds: 10
+            resources:
+              requests:
+                cpu: ${CPU_REQUEST}
+                memory: ${MEMORY_REQUEST}
+              limits:
+                cpu: ${CPU_LIMIT}
+                memory: ${MEMORY_LIMIT}
+            ports:
+              - containerPort: 8080
+                protocol: TCP
+              - containerPort: 8778
+                name: jolokia
+                protocol: TCP
+            volumeMounts:
+              - name: config
+                mountPath: /config
+              - name: pinhead
+                mountPath: /pinhead
+            workingDir: /
+        volumes:
+          - name: config
+            configMap:
+              name: rhsm-conduit-config
+          - name: pinhead
+            secret:
+              secretName: pinhead
+        restartPolicy: Always
+        terminationGracePeriodSeconds: 75
+    triggers:
+      - type: ConfigChange
+
+- apiVersion: v1
+  kind: Service
+  metadata:
+    name: rhsm-conduit
+  spec:
+    ports:
+      - port: 8080
+        protocol: TCP
+        targetPort: 8080
+    selector:
+      deploymentconfig: rhsm-conduit

--- a/templates/rhsm-conduit.yaml
+++ b/templates/rhsm-conduit.yaml
@@ -242,6 +242,8 @@ objects:
               secretName: pinhead
         restartPolicy: Always
         terminationGracePeriodSeconds: 75
+        imagePullSecrets:
+          - name: quay-cloudservices-pull
     triggers:
       - type: ConfigChange
 


### PR DESCRIPTION
See README.md changes for details on how to use.

Note if you want to test before our images are in quay, you can replace
the image reference with one reachable from the cluster:

```
cat templates/rhsm-conduit.yaml | sed 's#quay.io/cloudservices/rhsm-conduit#docker-registry.default.svc:5000/rhsm-ci/rhsm-conduit#' | sed '/quay/d' | oc apply -f -
```