### PR TITLE
Use List.contains instead of Arrays.binarySearch

### DIFF
--- a/src/main/java/org/candlepin/insights/orgsync/OrgSyncConfiguration.java
+++ b/src/main/java/org/candlepin/insights/orgsync/OrgSyncConfiguration.java
@@ -79,7 +79,7 @@ public class OrgSyncConfiguration implements SchedulingConfigurer {
             scheduler.schedule(orgSyncJob, new CronTrigger(cronExpression));
             log.info("OrgSync job scheduled to run at {}", cronExpression);
         }
-        else if (Arrays.binarySearch(environment.getActiveProfiles(), "orgsync") >= 0) {
+        else if (Arrays.asList(environment.getActiveProfiles()).contains("orgsync")) {
             scheduler.schedule(orgSyncJob, Instant.now());
             log.info("OrgSync job scheduled to run now");
         }


### PR DESCRIPTION
The binarySearch method requires the list to be sorted by natural value
prior to searching.  Not sorting it leads to undefined behavior.