### PR TITLE
Remove rhsm-conduit-config volume from template

### DIFF
--- a/templates/rhsm-conduit.yaml
+++ b/templates/rhsm-conduit.yaml
@@ -147,15 +147,10 @@ objects:
                 name: jolokia
                 protocol: TCP
             volumeMounts:
-              - name: config
-                mountPath: /config
               - name: pinhead
                 mountPath: /pinhead
             workingDir: /
         volumes:
-          - name: config
-            configMap:
-              name: rhsm-conduit-config
           - name: pinhead
             secret:
               secretName: pinhead


### PR DESCRIPTION
I partially removed in #157, but missed a couple places. Doh!