### PR TITLE
Move scheduling to templated CronJob

### DIFF
--- a/src/main/java/org/candlepin/insights/task/queue/kafka/KafkaTaskQueueConfiguration.java
+++ b/src/main/java/org/candlepin/insights/task/queue/kafka/KafkaTaskQueueConfiguration.java
@@ -30,6 +30,7 @@ import org.springframework.boot.autoconfigure.kafka.KafkaProperties;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.context.annotation.Primary;
+import org.springframework.context.annotation.Profile;
 import org.springframework.context.annotation.PropertySource;
 import org.springframework.kafka.annotation.EnableKafka;
 import org.springframework.kafka.config.KafkaListenerContainerFactory;
@@ -97,12 +98,14 @@ public class KafkaTaskQueueConfiguration {
 
     @Bean
     @ConditionalOnProperty(prefix = "rhsm-conduit.tasks", name = "queue", havingValue = "kafka")
+    @Profile("worker")
     public ConsumerFactory<String, TaskMessage> consumerFactory(KafkaProperties kafkaProperties) {
         return kafkaConfigurator.defaultConsumerFactory(kafkaProperties);
     }
 
     @Bean
     @ConditionalOnProperty(prefix = "rhsm-conduit.tasks", name = "queue", havingValue = "kafka")
+    @Profile("worker")
     KafkaListenerContainerFactory<ConcurrentMessageListenerContainer<String, TaskMessage>>
         kafkaListenerContainerFactory(ConsumerFactory<String, TaskMessage> consumerFactory,
         KafkaProperties kafkaProperties) {
@@ -121,6 +124,7 @@ public class KafkaTaskQueueConfiguration {
 
     @Bean
     @ConditionalOnProperty(prefix = "rhsm-conduit.tasks", name = "queue", havingValue = "kafka")
+    @Profile("worker")
     public KafkaTaskProcessor taskProcessor(TaskFactory taskFactory) {
         return new KafkaTaskProcessor(taskFactory);
     }

--- a/src/main/java/org/candlepin/insights/task/queue/kafka/KafkaTaskQueueConfiguration.java
+++ b/src/main/java/org/candlepin/insights/task/queue/kafka/KafkaTaskQueueConfiguration.java
@@ -29,6 +29,7 @@ import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
 import org.springframework.boot.autoconfigure.kafka.KafkaProperties;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.context.annotation.DependsOn;
 import org.springframework.context.annotation.Primary;
 import org.springframework.context.annotation.Profile;
 import org.springframework.context.annotation.PropertySource;
@@ -80,6 +81,7 @@ public class KafkaTaskQueueConfiguration {
     //
 
     @Bean
+    @DependsOn("poolScheduler") // this ensures the producer can shut down cleanly when used in a job
     @ConditionalOnProperty(prefix = "rhsm-conduit.tasks", name = "queue", havingValue = "kafka")
     public ProducerFactory<String, TaskMessage> producerFactory(KafkaProperties kafkaProperties) {
         return kafkaConfigurator.defaultProducerFactory(kafkaProperties);

--- a/src/test/resources/kafka_schema_registry_test.properties
+++ b/src/test/resources/kafka_schema_registry_test.properties
@@ -1,6 +1,9 @@
 # A configuration file to be used when testing kafka integration.
 
+spring.profiles.active=worker
+
 rhsm-conduit.version=TEST
+
 
 # Stub out the inventory and pinhead services
 rhsm-conduit.inventory-service.useStub=true

--- a/src/test/resources/kafka_test.properties
+++ b/src/test/resources/kafka_test.properties
@@ -1,5 +1,7 @@
 # A configuration file to be used when testing kafka integration.
 
+spring.profiles.active=worker
+
 rhsm-conduit.version=TEST
 
 # Stub out the inventory and pinhead services

--- a/templates/rhsm-conduit.yaml
+++ b/templates/rhsm-conduit.yaml
@@ -22,7 +22,7 @@ parameters:
   - name: KAFKA_CONSUMER_MAX_POLL_INTERVAL_MS
     value: '3600000'
   - name: ORG_SYNC_SCHEDULE
-    value: 0 0 0 * * ?
+    value: 0 0 * * *
   - name: REPLICAS
     value: '1'
   - name: IMAGE_TAG
@@ -71,6 +71,8 @@ objects:
           - image: quay.io/cloudservices/rhsm-conduit:${IMAGE_TAG}
             name: rhsm-conduit
             env:
+              - name: JAVA_OPTIONS
+                value: -Dspring.profiles.active=worker
               - name: LOG_FILE
                 value: /logs/server.log
               - name: JAVA_MAX_MEM_RATIO
@@ -85,8 +87,6 @@ objects:
                 value: ${LOGGING_LEVEL}
               - name: PINHEAD_URL
                 value: ${PINHEAD_URL}
-              - name: ORG_SYNC_SCHEDULE
-                value: ${ORG_SYNC_SCHEDULE}
               - name: KAFKA_BOOTSTRAP_HOST
                 value: ${KAFKA_BOOTSTRAP_HOST}
               - name: KAFKA_MESSAGE_THREADS
@@ -218,3 +218,69 @@ objects:
         targetPort: 8080
     selector:
       deploymentconfig: rhsm-conduit
+
+- apiVersion: batch/v1beta1
+  kind: CronJob
+  metadata:
+    name: rhsm-conduit-cron-sync
+  spec:
+    schedule: ${ORG_SYNC_SCHEDULE}
+    jobTemplate:
+      spec:
+        activeDeadlineSeconds: 1800
+        template:
+          spec:
+            activeDeadlineSeconds: 1800
+            restartPolicy: Never
+            imagePullSecrets:
+              - name: quay-cloudservices-pull
+            containers:
+              - image: quay.io/cloudservices/rhsm-conduit:${IMAGE_TAG}
+                name: rhsm-conduit-cron-sync
+                env:
+                - name: JAVA_OPTIONS
+                  value: -Dspring.profiles.active=orgsync
+                - name: JAVA_MAX_MEM_RATIO
+                  value: '85'
+                - name: GC_MAX_METASPACE_SIZE
+                  value: '256'
+                - name: TASK_QUEUE_TYPE
+                  value: kafka
+                - name: LOGGING_LEVEL_ROOT
+                  value: ${LOGGING_LEVEL_ROOT}
+                - name: LOGGING_LEVEL_ORG_CANDLEPIN
+                  value: ${LOGGING_LEVEL}
+                - name: KAFKA_BOOTSTRAP_HOST
+                  value: ${KAFKA_BOOTSTRAP_HOST}
+                - name: DATABASE_HOST
+                  valueFrom:
+                    secretKeyRef:
+                      name: rhsm-db
+                      key: db.host
+                - name: DATABASE_PORT
+                  valueFrom:
+                    secretKeyRef:
+                      name: rhsm-db
+                      key: db.port
+                - name: DATABASE_USERNAME
+                  valueFrom:
+                    secretKeyRef:
+                      name: rhsm-db
+                      key: db.user
+                - name: DATABASE_PASSWORD
+                  valueFrom:
+                    secretKeyRef:
+                      name: rhsm-db
+                      key: db.password
+                - name: DATABASE_DATABASE
+                  valueFrom:
+                    secretKeyRef:
+                      name: rhsm-db
+                      key: db.name
+                resources:
+                  requests:
+                    cpu: ${CPU_REQUEST}
+                    memory: ${MEMORY_REQUEST}
+                  limits:
+                    cpu: ${CPU_LIMIT}
+                    memory: ${MEMORY_LIMIT}


### PR DESCRIPTION
Note that I annotated the consumers and related beans with `worker` profile as we do in rhsm-subscriptions. Otherwise, the scheduler node tries to do work until the job finishes (not harmful, but unnecessary).

To test observe CI (deployed there); if you want to adjust the schedule try something like:

```
oc process -f templates/rhsm-conduit.yaml --param=KAFKA_BOOTSTRAP_HOST=platform-mq-ci-kafka-bootstrap.platform-mq-ci.svc.cluster.local --param=IMAGE_TAG=ebdbee4 --param=PINHEAD_URL=https://systems.qa.api.redhat.com/v1 '--param=ORG_SYNC_SCHEDULE=20 * * * *' | oc apply -f -
```