### PR TITLE
Add jolokia actuator

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -92,6 +92,7 @@ allprojects {
             dependency "com.amazonaws:aws-java-sdk-logs:$aws_sdk_version"
             dependency "com.amazonaws:aws-java-sdk-ec2:$aws_sdk_version"
             dependency "com.google.guava:guava:$guava_version"
+            dependency "io.hawt:hawtio-springboot:2.10.1"
             dependencySet(group: "org.jboss.resteasy", version: "$resteasy_version") {
                 entry "resteasy-client"
                 entry "resteasy-multipart-provider"
@@ -193,6 +194,7 @@ dependencies {
     }
     runtime "org.jolokia:jolokia-core"
     runtime "com.j256.cloudwatchlogbackappender:cloudwatchlogbackappender"
+    runtime "io.hawt:hawtio-springboot"
 }
 
 // Add a custom task to output dependency info in a machine parseable format. Used to generate dependency

--- a/build.gradle
+++ b/build.gradle
@@ -182,6 +182,7 @@ dependencies {
     compile "org.apache.commons:commons-csv"
     compile "com.google.guava:guava"
     compile "org.postgresql:postgresql"
+    compile "io.hawt:hawtio-springboot"
 
     // Test dependencies
     testCompile "org.springframework.kafka:spring-kafka-test"
@@ -194,7 +195,6 @@ dependencies {
     }
     runtime "org.jolokia:jolokia-core"
     runtime "com.j256.cloudwatchlogbackappender:cloudwatchlogbackappender"
-    runtime "io.hawt:hawtio-springboot"
 }
 
 // Add a custom task to output dependency info in a machine parseable format. Used to generate dependency

--- a/build.gradle
+++ b/build.gradle
@@ -191,6 +191,7 @@ dependencies {
     runtime("org.jboss.resteasy:resteasy-validator-provider-11") {
         exclude group: 'org.hibernate' // exclude older hibernate validator
     }
+    runtime "org.jolokia:jolokia-core"
     runtime "com.j256.cloudwatchlogbackappender:cloudwatchlogbackappender"
 }
 

--- a/src/main/java/org/candlepin/insights/ApplicationConfiguration.java
+++ b/src/main/java/org/candlepin/insights/ApplicationConfiguration.java
@@ -28,7 +28,6 @@ import org.jboss.resteasy.springboot.ResteasyAutoConfiguration;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.config.BeanFactoryPostProcessor;
 import org.springframework.boot.context.properties.ConfigurationProperties;
-import org.springframework.boot.context.properties.EnableConfigurationProperties;
 import org.springframework.boot.web.servlet.ServletContextInitializer;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
@@ -59,7 +58,6 @@ import javax.validation.Validator;
 @EnableAspectJAutoProxy
 @EnableScheduling
 @Import(ResteasyAutoConfiguration.class) // needed to be able to reference ResteasyApplicationBuilder
-@EnableConfigurationProperties(ApplicationProperties.class)
 // The values in application.yaml should already be loaded by default
 @PropertySource("classpath:/rhsm-conduit.properties")
 public class ApplicationConfiguration implements WebMvcConfigurer {

--- a/src/main/java/org/candlepin/insights/ApplicationProperties.java
+++ b/src/main/java/org/candlepin/insights/ApplicationProperties.java
@@ -32,6 +32,7 @@ public class ApplicationProperties {
     private String version;
     private boolean prettyPrintJson = false;
     private boolean devMode = false;
+    private String hawtioBasePath;
 
     public String getVersion() {
         return version;
@@ -55,5 +56,13 @@ public class ApplicationProperties {
 
     public void setDevMode(boolean devMode) {
         this.devMode = devMode;
+    }
+
+    public String getHawtioBasePath() {
+        return hawtioBasePath;
+    }
+
+    public void setHawtioBasePath(String hawtioBasePath) {
+        this.hawtioBasePath = hawtioBasePath;
     }
 }

--- a/src/main/java/org/candlepin/insights/util/HawtioConfiguration.java
+++ b/src/main/java/org/candlepin/insights/util/HawtioConfiguration.java
@@ -1,0 +1,104 @@
+/*
+ * Copyright (c) 2009 - 2020 Red Hat, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ *
+ * Red Hat trademarks are not licensed under GPLv3. No permission is
+ * granted to use or replicate Red Hat trademarks that are incorporated
+ * in this software or its documentation.
+ */
+package org.candlepin.insights.util;
+
+import static io.hawt.web.filters.BaseTagHrefFilter.*;
+
+import org.candlepin.insights.ApplicationProperties;
+
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.beans.factory.annotation.Qualifier;
+import org.springframework.boot.web.servlet.FilterRegistrationBean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.util.StringUtils;
+
+import io.hawt.web.filters.BaseTagHrefFilter;
+
+import java.util.Collections;
+import java.util.Enumeration;
+import java.util.HashMap;
+import java.util.Map;
+
+import javax.servlet.FilterConfig;
+import javax.servlet.ServletContext;
+import javax.servlet.ServletException;
+
+/**
+ * Configuration that modifies the base path used by the Hawtio frontend.
+ *
+ * This enables us to deploy the console behind a reverse proxy with a different prefix.
+ *
+ * For example, if hawtio is deployed at /actuator/hawtio, and the reverse proxy configuration results in a
+ * browser URL of /rhsm-conduit/actuator/hawtio, then setting `rhsm-conduit.hawtioBasePath` to
+ * /rhsm-conduit/actuator/hawtio forces the frontend to return the proper URLs for JavaScript/CSS.
+ */
+@Configuration
+public class HawtioConfiguration {
+    @Autowired
+    public void modifyBaseTagHrefFilter(
+        @Qualifier("baseTagHrefFilter") FilterRegistrationBean<BaseTagHrefFilter> filter,
+        ServletContext servletContext,
+        ApplicationProperties props
+    ) throws ServletException {
+        if (!StringUtils.isEmpty(props.getHawtioBasePath())) {
+            BaseTagHrefFilter baseTagHrefFilter = filter.getFilter();
+            BaseTagHrefFilterConfigOverride filterConfig =
+                new BaseTagHrefFilterConfigOverride(servletContext);
+            filterConfig.setParameter(PARAM_APPLICATION_CONTEXT_PATH, props.getHawtioBasePath());
+            baseTagHrefFilter.init(filterConfig);
+        }
+    }
+
+    private static class BaseTagHrefFilterConfigOverride implements FilterConfig {
+
+        private final ServletContext servletContext;
+        private final Map<String, String> parameters = new HashMap<>();
+
+        public BaseTagHrefFilterConfigOverride(ServletContext servletContext) {
+            this.servletContext = servletContext;
+        }
+
+        @Override
+        public String getFilterName() {
+            // not used
+            return null;
+        }
+
+        @Override
+        public ServletContext getServletContext() {
+            return servletContext;
+        }
+
+        @Override
+        public String getInitParameter(String name) {
+            return parameters.get(name);
+        }
+
+        @Override
+        public Enumeration<String> getInitParameterNames() {
+            return Collections.enumeration(parameters.keySet());
+        }
+
+        public void setParameter(String name, String value) {
+            parameters.put(name, value);
+        }
+    }
+}

--- a/src/main/resources/application.yaml
+++ b/src/main/resources/application.yaml
@@ -13,6 +13,7 @@ management:
     web:
       exposure:
         include:
+          - hawtio
           - health
           - info
           - jolokia

--- a/src/main/resources/application.yaml
+++ b/src/main/resources/application.yaml
@@ -15,6 +15,7 @@ management:
         include:
           - health
           - info
+          - jolokia
           - prometheus
   endpoint:
     shutdown:

--- a/src/main/resources/rhsm-conduit.properties
+++ b/src/main/resources/rhsm-conduit.properties
@@ -76,7 +76,11 @@ rhsm-subscriptions.datasource.platform=postgresql
 ###################################
 # Hawtio Console Configuration
 ###################################
-hawtio.authenticationEnabled=false
+# Base path override for reverse proxy support
+rhsm-conduit.hawtioBasePath=${HAWTIO_BASE_PATH:}
+# See https://hawt.io/docs/configuration/ for details on built-in hawtio config
+hawtio.authenticationEnabled=${HAWTIO_AUTHENTICATION_ENABLED:false}
 # disable the remote connection tab, we do not need it
-hawtio.disableProxy=true
-rhsm-subscriptions.hawtioBasePath=${HAWTIO_BASE_PATH}
+hawtio.disableProxy=${HAWTIO_DISABLE_PROXY:true}
+hawtio.proxyAllowlist=${HAWTIO_PROXY_ALLOWLIST:localhost,127.0.0.1}
+hawtio.localAddressProbing=${HAWTIO_LOCAL_ADDRESS_PROBING:true}

--- a/src/main/resources/rhsm-conduit.properties
+++ b/src/main/resources/rhsm-conduit.properties
@@ -79,3 +79,4 @@ rhsm-subscriptions.datasource.platform=postgresql
 hawtio.authenticationEnabled=false
 # disable the remote connection tab, we do not need it
 hawtio.disableProxy=true
+rhsm-subscriptions.hawtioBasePath=${HAWTIO_BASE_PATH}

--- a/src/main/resources/rhsm-conduit.properties
+++ b/src/main/resources/rhsm-conduit.properties
@@ -72,3 +72,10 @@ rhsm-subscriptions.datasource.username=${DATABASE_USERNAME:rhsm-subscriptions}
 rhsm-subscriptions.datasource.password=${DATABASE_PASSWORD:rhsm-subscriptions}
 rhsm-subscriptions.datasource.driver-class-name=org.postgresql.Driver
 rhsm-subscriptions.datasource.platform=postgresql
+
+###################################
+# Hawtio Console Configuration
+###################################
+hawtio.authenticationEnabled=false
+# disable the remote connection tab, we do not need it
+hawtio.disableProxy=true

--- a/templates/rhsm-conduit.yaml
+++ b/templates/rhsm-conduit.yaml
@@ -13,7 +13,7 @@ parameters:
   - name: AB_JOLOKIA_OFF
     value: 'true'
   - name: HAWTIO_BASE_PATH
-    value: /rhsm-conduit/actuator/hawtio
+    value: /app/rhsm-conduit/actuator/hawtio
   - name: KAFKA_BOOTSTRAP_HOST
     required: true
   - name: PINHEAD_URL

--- a/templates/rhsm-conduit.yaml
+++ b/templates/rhsm-conduit.yaml
@@ -9,9 +9,6 @@ metadata:
   name: rhsm-conduit
 
 parameters:
-  # turn off built-in jolokia, so that the spring boot jolokia actuator will work
-  - name: AB_JOLOKIA_OFF
-    value: 'true'
   - name: HAWTIO_BASE_PATH
     value: /app/rhsm-conduit/actuator/hawtio
   - name: KAFKA_BOOTSTRAP_HOST
@@ -76,6 +73,11 @@ objects:
           - image: quay.io/cloudservices/rhsm-conduit:${IMAGE_TAG}
             name: rhsm-conduit
             env:
+              # turn off built-in jolokia, so that the spring boot jolokia actuator will work
+              - name: AB_JOLOKIA_OFF
+                value: 'true'
+              - name: HAWTIO_BASE_PATH
+                value: ${HAWTIO_BASE_PATH}
               - name: JAVA_OPTIONS
                 value: -Dspring.profiles.active=worker
               - name: LOG_FILE

--- a/templates/rhsm-conduit.yaml
+++ b/templates/rhsm-conduit.yaml
@@ -9,6 +9,8 @@ metadata:
   name: rhsm-conduit
 
 parameters:
+  - name: HAWTIO_BASE_PATH
+    value: /rhsm-conduit/actuator/hawtio
   - name: KAFKA_BOOTSTRAP_HOST
     required: true
   - name: PINHEAD_URL

--- a/templates/rhsm-conduit.yaml
+++ b/templates/rhsm-conduit.yaml
@@ -9,6 +9,9 @@ metadata:
   name: rhsm-conduit
 
 parameters:
+  # turn off built-in jolokia, so that the spring boot jolokia actuator will work
+  - name: AB_JOLOKIA_OFF
+    value: 'true'
   - name: HAWTIO_BASE_PATH
     value: /rhsm-conduit/actuator/hawtio
   - name: KAFKA_BOOTSTRAP_HOST
@@ -156,9 +159,6 @@ objects:
                 memory: ${MEMORY_LIMIT}
             ports:
               - containerPort: 8080
-                protocol: TCP
-              - containerPort: 8778
-                name: jolokia
                 protocol: TCP
             volumeMounts:
               - name: pinhead


### PR DESCRIPTION
Note that I did not apply any security-related changes here. The API gateway will already perform authn/authz for this endpoint, and since we plan to merge rhsm-conduit and rhsm-subscriptions into a single codebase in the future, it provides little value to do so now.

Once we merge the projects, we should apply logging of the principal as done in RedHatInsights/rhsm-subscriptions#175.

To test try, `curl http://localhost/actuator/jolokia/list` and observe a listing of JMX beans. Try other JMX invocations as desired.