### PR TITLE
Port jolokia restrictor changes from rhsm-subscriptions

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -93,6 +93,7 @@ allprojects {
             dependency "com.amazonaws:aws-java-sdk-ec2:$aws_sdk_version"
             dependency "com.google.guava:guava:$guava_version"
             dependency "io.hawt:hawtio-springboot:2.10.1"
+            dependency "org.jolokia:jolokia-core:1.6.2"
             dependencySet(group: "org.jboss.resteasy", version: "$resteasy_version") {
                 entry "resteasy-client"
                 entry "resteasy-multipart-provider"

--- a/src/main/java/org/candlepin/insights/ApplicationProperties.java
+++ b/src/main/java/org/candlepin/insights/ApplicationProperties.java
@@ -33,6 +33,8 @@ public class ApplicationProperties {
     private boolean prettyPrintJson = false;
     private boolean devMode = false;
     private String hawtioBasePath;
+    private String antiCsrfDomainSuffix = ".redhat.com";
+    private int antiCsrfPort = 443;
 
     public String getVersion() {
         return version;
@@ -64,5 +66,21 @@ public class ApplicationProperties {
 
     public void setHawtioBasePath(String hawtioBasePath) {
         this.hawtioBasePath = hawtioBasePath;
+    }
+
+    public String getAntiCsrfDomainSuffix() {
+        return antiCsrfDomainSuffix;
+    }
+
+    public void setAntiCsrfDomainSuffix(String antiCsrfDomainSuffix) {
+        this.antiCsrfDomainSuffix = antiCsrfDomainSuffix;
+    }
+
+    public int getAntiCsrfPort() {
+        return antiCsrfPort;
+    }
+
+    public void setAntiCsrfPort(int antiCsrfPort) {
+        this.antiCsrfPort = antiCsrfPort;
     }
 }

--- a/src/main/java/org/candlepin/insights/security/JolokiaRestrictor.java
+++ b/src/main/java/org/candlepin/insights/security/JolokiaRestrictor.java
@@ -1,0 +1,65 @@
+/*
+ * Copyright (c) 2009 - 2020 Red Hat, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ *
+ * Red Hat trademarks are not licensed under GPLv3. No permission is
+ * granted to use or replicate Red Hat trademarks that are incorporated
+ * in this software or its documentation.
+ */
+package org.candlepin.insights.security;
+
+
+
+import org.candlepin.insights.ApplicationProperties;
+
+import org.jolokia.config.Configuration;
+
+import io.hawt.system.RBACRestrictor;
+
+import java.net.URI;
+
+/**
+ * Apply origin/referer restrictions against all Jolokia requests.
+ */
+public class JolokiaRestrictor extends RBACRestrictor {
+
+    private static ApplicationProperties props;
+
+    public JolokiaRestrictor(Configuration config) {
+        super(config);
+    }
+
+    public static void setApplicationProperties(ApplicationProperties properties) {
+        JolokiaRestrictor.props = properties;
+    }
+
+    @Override
+    public boolean isOriginAllowed(String origin, boolean strictCheck) {
+        if (props == null) {
+            // deny all until configured
+            return false;
+        }
+        if (props.isDevMode()) {
+            return true;
+        }
+        if (props.getAntiCsrfDomainSuffix() == null || origin == null) {
+            return false;
+        }
+        // NOTE: although the method name suggests origin, referer can be passed instead if origin missing.
+        URI uri = URI.create(origin);
+        return uri.getHost().endsWith(props.getAntiCsrfDomainSuffix()) &&
+            (uri.getPort() == -1 || uri.getPort() == props.getAntiCsrfPort());
+    }
+}

--- a/src/main/java/org/candlepin/insights/util/HawtioConfiguration.java
+++ b/src/main/java/org/candlepin/insights/util/HawtioConfiguration.java
@@ -23,6 +23,7 @@ package org.candlepin.insights.util;
 import static io.hawt.web.filters.BaseTagHrefFilter.*;
 
 import org.candlepin.insights.ApplicationProperties;
+import org.candlepin.insights.security.JolokiaRestrictor;
 
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Qualifier;
@@ -65,6 +66,11 @@ public class HawtioConfiguration {
             filterConfig.setParameter(PARAM_APPLICATION_CONTEXT_PATH, props.getHawtioBasePath());
             baseTagHrefFilter.init(filterConfig);
         }
+    }
+
+    @Autowired
+    public void configureJolokiaRestrictor(ApplicationProperties props) {
+        JolokiaRestrictor.setApplicationProperties(props);
     }
 
     private static class BaseTagHrefFilterConfigOverride implements FilterConfig {

--- a/src/main/resources/application.yaml
+++ b/src/main/resources/application.yaml
@@ -23,3 +23,6 @@ management:
       enabled: true
     prometheus:
       enabled: true
+    jolokia:
+      config:
+        restrictorClass: org.candlepin.insights.security.JolokiaRestrictor


### PR DESCRIPTION
For context, see RedHatInsights/rhsm-subscriptions#189.

For some reason, the jolokia-core version that was being pulled in was
different than in rhsm-subscriptions, so I had to override in
build.gradle.