### PR TITLE
Ignore config file for envdir

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,5 @@
+.envrc
+
 *~
 *.class
 *.log*


### PR DESCRIPTION
Conduit does not currently compile with java 11. If java 11 is your current JDK then the following workaround can be used to automatically switch to 1.8 in the CLI while working on conduit.

```
$ sudo dnf install envdir
$ echo 'eval "$(direnv hook bash)"' >> .bashrc
$ cd <YOUR_CONDUIT_CHECKOUT>
$ direnv allow ; echo JAVA_HOME=/usr/lib/jvm/java-1.8.0 > .envrc
```

NOTE: You may need to exit your console or move out of the current dir and back into the conduit checkout.

```
# verify that JAVA_HOME was set correctly
echo $JAVA_HOME
```