### PR TITLE
Propagate exceptions back to JMX client

### DIFF
--- a/src/main/java/org/candlepin/insights/jmx/RhsmConduitJmxBean.java
+++ b/src/main/java/org/candlepin/insights/jmx/RhsmConduitJmxBean.java
@@ -42,6 +42,8 @@ import java.util.stream.Collectors;
  */
 @Component
 @ManagedResource
+// must log, then throw because the exception is passed to client and not logged.
+@SuppressWarnings("java:S2139")
 public class RhsmConduitJmxBean {
 
     private static final Logger log = LoggerFactory.getLogger(RhsmConduitJmxBean.class);
@@ -60,50 +62,70 @@ public class RhsmConduitJmxBean {
     }
 
     @ManagedOperation(description = "Trigger a sync for a given Org ID")
-    public void syncOrg(String orgId) {
-        log.info("Starting JMX-initiated sync for org ID {}", orgId);
+    public void syncOrg(String orgId) throws RhsmJmxException {
         try {
+            log.info("Starting JMX-initiated sync for org ID {}", orgId);
             controller.updateInventoryForOrg(orgId);
         }
         catch (Exception e) {
             log.error("Error during JMX-initiated sync for org ID {}", orgId, e);
+            throw new RhsmJmxException(e);
         }
     }
 
     @ManagedOperation(description = "Sync all orgs from the configured org list")
-    public void syncFullOrgList() {
+    public void syncFullOrgList() throws RhsmJmxException {
         log.info("Starting JMX-initiated sync for all configured orgs");
         try {
             tasks.syncFullOrgList();
         }
         catch (Exception e) {
             log.error("Error during JMX-initiated sync for full org list", e);
+            throw new RhsmJmxException(e);
         }
     }
 
     @ManagedOperation(description = "Add some orgs to the database sync list")
     @ManagedOperationParameter(name = "orgs", description = "comma-separated org list (whitespace ignored)")
-    public void addOrgsToSyncList(String orgs) {
-        List<OrgConfig> orgList = extractOrgList(orgs);
+    public void addOrgsToSyncList(String orgs) throws RhsmJmxException {
+        try {
+            List<OrgConfig> orgList = extractOrgList(orgs);
 
-        log.info("Adding {} orgs to DB sync list", orgList.size());
+            log.info("Adding {} orgs to DB sync list via JMX", orgList.size());
 
-        repo.saveAll(orgList);
+            repo.saveAll(orgList);
+        }
+        catch (Exception e) {
+            log.error("Error while adding orgs to DB sync list via JMX", e);
+            throw new RhsmJmxException(e);
+        }
     }
 
     @ManagedOperation(description = "Remove some orgs from the database sync list")
     @ManagedOperationParameter(name = "orgs", description = "comma-separated org list (whitespace ignored)")
-    public void removeOrgsFromSyncList(String orgs) {
-        List<OrgConfig> orgList = extractOrgList(orgs);
+    public void removeOrgsFromSyncList(String orgs) throws RhsmJmxException {
+        try {
+            List<OrgConfig> orgList = extractOrgList(orgs);
 
-        log.info("Removing {} orgs from DB sync list", orgList.size());
+            log.info("Removing {} orgs from DB sync list via JMX", orgList.size());
 
-        repo.deleteAll(orgList);
+            repo.deleteAll(orgList);
+        }
+        catch (Exception e) {
+            log.error("Error removing orgs from DB sync list via JMX", e);
+            throw new RhsmJmxException(e);
+        }
     }
 
     @ManagedOperation(description = "Check if an org is present in the database sync list")
-    public boolean hasOrgInSyncList(String orgId) {
-        return repo.existsById(orgId);
+    public boolean hasOrgInSyncList(String orgId) throws RhsmJmxException {
+        try {
+            return repo.existsById(orgId);
+        }
+        catch (Exception e) {
+            log.error("Unable to determine if org {} exists via JMX", orgId);
+            throw new RhsmJmxException(e);
+        }
     }
 
     private List<OrgConfig> extractOrgList(String orgs) {

--- a/src/main/java/org/candlepin/insights/jmx/RhsmJmxException.java
+++ b/src/main/java/org/candlepin/insights/jmx/RhsmJmxException.java
@@ -1,0 +1,32 @@
+/*
+ * Copyright (c) 2009 - 2019 Red Hat, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ *
+ * Red Hat trademarks are not licensed under GPLv3. No permission is
+ * granted to use or replicate Red Hat trademarks that are incorporated
+ * in this software or its documentation.
+ */
+package org.candlepin.insights.jmx;
+
+/**
+ * Thrown by JMX beans when an error occurs executing a method. When throwing an
+ * exception, be sure to log it first, otherwise it will get returned to the client.
+ */
+public class RhsmJmxException extends Exception {
+
+    public RhsmJmxException(Throwable t) {
+        super(t);
+    }
+}

--- a/src/test/java/org/candlepin/insights/jmx/RhsmConduitJmxBeanTest.java
+++ b/src/test/java/org/candlepin/insights/jmx/RhsmConduitJmxBeanTest.java
@@ -52,28 +52,28 @@ class RhsmConduitJmxBeanTest {
     TaskManager tasks;
 
     @Test
-    void testHandlesCommas() {
+    void testHandlesCommas() throws Exception {
         RhsmConduitJmxBean jmxBean = new RhsmConduitJmxBean(controller, repo, tasks, clock);
         jmxBean.addOrgsToSyncList("1,2,3");
         verify(repo).saveAll(matchOrgs("1", "2", "3"));
     }
 
     @Test
-    void testHandlesWhitespace() {
+    void testHandlesWhitespace() throws Exception {
         RhsmConduitJmxBean jmxBean = new RhsmConduitJmxBean(controller, repo, tasks, clock);
         jmxBean.addOrgsToSyncList("1 2\n3");
         verify(repo).saveAll(matchOrgs("1", "2", "3"));
     }
 
     @Test
-    void testHandlesAllDelimitersTogether() {
+    void testHandlesAllDelimitersTogether() throws Exception {
         RhsmConduitJmxBean jmxBean = new RhsmConduitJmxBean(controller, repo, tasks, clock);
         jmxBean.addOrgsToSyncList("1,2 3\n4");
         verify(repo).saveAll(matchOrgs("1", "2", "3", "4"));
     }
 
     @Test
-    void testHandlesAllDelimitersTogetherInCombination() {
+    void testHandlesAllDelimitersTogetherInCombination() throws Exception {
         RhsmConduitJmxBean jmxBean = new RhsmConduitJmxBean(controller, repo, tasks, clock);
         jmxBean.addOrgsToSyncList("1,\n2 ,3 \n4 ,\n5");
         verify(repo).saveAll(matchOrgs("1", "2", "3", "4", "5"));


### PR DESCRIPTION
When an exception is thrown by a JMX bean, we must first
log the exception and then rethrow it. If we do not log
the exception, it will not make it to our log file, and
only the JMX client will receive the error message

**Testing**
Launch the app and use hawtio to sync an org that does not exist. The client API will throw an exception because the org does not exist and the JMX client will display _success_.

Apply this patch and try it again. This time, note that the log message is printed and hawtio displays the exception message.