### PR TITLE
ENT-3140: Set the truststore for RHSM

### DIFF
--- a/README.md
+++ b/README.md
@@ -183,6 +183,8 @@ for a discussion of extension points.
 * `RHSM_URL`: RHSM service URL
 * `RHSM_KEYSTORE`: path to keystore with client cert
 * `RHSM_KEYSTORE_PASSWORD`: RHSM API client cert keystore password
+* `RHSM_TRUSTSTORE`: path to truststore for verification of RHSM endpoint
+* `RHSM_KEYSTORE_PASSWORD`: truststore password
 * `RHSM_BATCH_SIZE`: host sync batch size
 * `RHSM_MAX_CONNECTIONS`: maximum concurrent connections to RHSM API
 * `INVENTORY_USE_STUB`: Use stubbed inventory REST API

--- a/rhsm-client/src/main/java/org/candlepin/insights/rhsm/client/X509ApiClientFactoryConfiguration.java
+++ b/rhsm-client/src/main/java/org/candlepin/insights/rhsm/client/X509ApiClientFactoryConfiguration.java
@@ -22,6 +22,7 @@
 package org.candlepin.insights.rhsm.client;
 
 import org.apache.http.conn.ssl.DefaultHostnameVerifier;
+import org.springframework.util.StringUtils;
 
 import java.io.ByteArrayInputStream;
 import java.io.IOException;
@@ -110,7 +111,7 @@ public class X509ApiClientFactoryConfiguration {
     }
 
     public boolean usesDefaultTruststore() {
-        return getTruststoreFile() == null;
+        return (StringUtils.isEmpty(getTruststoreFile()) || getTruststorePassword() == null);
     }
 
     public String toString() {

--- a/src/main/resources/rhsm-conduit.properties
+++ b/src/main/resources/rhsm-conduit.properties
@@ -25,6 +25,8 @@ rhsm-conduit.rhsm.useStub=${RHSM_USE_STUB:false}
 rhsm-conduit.rhsm.url=${RHSM_URL:http://localhost:9090}
 rhsm-conduit.rhsm.keystore_file=${RHSM_KEYSTORE:}
 rhsm-conduit.rhsm.keystore_password=${RHSM_KEYSTORE_PASSWORD:changeit}
+rhsm-conduit.rhsm.truststore_file=${RHSM_TRUSTSTORE:}
+rhsm-conduit.rhsm.truststore_password=${RHSM_TRUSTSTORE_PASSWORD:changeit}
 rhsm-conduit.rhsm.requestBatchSize=${RHSM_BATCH_SIZE:1000}
 rhsm-conduit.rhsm.maxConnections=${RHSM_MAX_CONNECTIONS:100}
 

--- a/templates/rhsm-conduit.yaml
+++ b/templates/rhsm-conduit.yaml
@@ -136,6 +136,13 @@ objects:
                     key: keystore_password
               - name: RHSM_KEYSTORE
                 value: /pinhead/keystore.jks
+              - name: RHSM_TRUSTSTORE_PASSWORD
+                valueFrom:
+                  secretKeyRef:
+                    name: tls
+                    key: keystore_password
+              - name: RHSM_TRUSTSTORE
+                value: /pinhead/truststore.jks
             livenessProbe:
               failureThreshold: 3
               httpGet:


### PR DESCRIPTION
The certificate used by the RHSM API endpoints is signed by a cert not in the default system truststore. Therefore, we need to add it explicitly to the truststore. Happily, our secret already has the proper truststore set up, so only a template change is needed.

This is why neither I nor @mstead noticed this issue locally (we both have system truststores with the proper certificate already in place).